### PR TITLE
Add NetworkMode to RuntimeContainer

### DIFF
--- a/context.go
+++ b/context.go
@@ -88,6 +88,7 @@ type RuntimeContainer struct {
 	Gateway      string
 	Name         string
 	Hostname     string
+	NetworkMode  string
 	Image        DockerImage
 	Env          map[string]string
 	Volumes      map[string]Volume

--- a/generator.go
+++ b/generator.go
@@ -379,6 +379,7 @@ func (g *generator) getContainers() ([]*RuntimeContainer, error) {
 			Name:         strings.TrimLeft(container.Name, "/"),
 			Hostname:     container.Config.Hostname,
 			Gateway:      container.NetworkSettings.Gateway,
+			NetworkMode:  container.HostConfig.NetworkMode,
 			Addresses:    []Address{},
 			Networks:     []Network{},
 			Env:          make(map[string]string),

--- a/generator_test.go
+++ b/generator_test.go
@@ -79,6 +79,9 @@ func TestGenerateFromEvents(t *testing.T) {
 				Cmd:          []string{"/bin/sh"},
 				Image:        "base:latest",
 			},
+			HostConfig: &docker.HostConfig{
+				NetworkMode: "container:d246e2c9e3d465d96359c942e91de493f6d51a01ba33900d865180d64c34ee91",
+			},
 			State: docker.State{
 				Running:   true,
 				Pid:       400,

--- a/template_test.go
+++ b/template_test.go
@@ -71,7 +71,7 @@ func TestKeysEmpty(t *testing.T) {
 	}
 
 	if len(input) != vk.Len() {
-		t.Fatalf("Incorrect key count; expected %s, got %s", len(input), vk.Len())
+		t.Fatalf("Incorrect key count; expected %d, got %d", len(input), vk.Len())
 	}
 }
 
@@ -269,11 +269,11 @@ func TestGroupByMulti(t *testing.T) {
 	}
 
 	if len(groups["demo1.localhost"]) != 2 {
-		t.Fatalf("expected 2 got %s", len(groups["demo1.localhost"]))
+		t.Fatalf("expected 2 got %d", len(groups["demo1.localhost"]))
 	}
 
 	if len(groups["demo2.localhost"]) != 1 {
-		t.Fatalf("expected 1 got %s", len(groups["demo2.localhost"]))
+		t.Fatalf("expected 1 got %d", len(groups["demo2.localhost"]))
 	}
 	if groups["demo2.localhost"][0].(RuntimeContainer).ID != "3" {
 		t.Fatalf("expected 2 got %s", groups["demo2.localhost"][0].(RuntimeContainer).ID)
@@ -785,7 +785,7 @@ func TestJson(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(decoded) != len(containers) {
-		t.Fatal("Incorrect unmarshaled container count. Expected %d, got %d.", len(containers), len(decoded))
+		t.Fatalf("Incorrect unmarshaled container count. Expected %d, got %d.", len(containers), len(decoded))
 	}
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -30,7 +30,7 @@ func TestDockerHostEndpoint(t *testing.T) {
 
 	endpoint, err := GetEndpoint("")
 	if err != nil {
-		t.Fatal("%s", err)
+		t.Fatalf("%s", err)
 	}
 
 	if endpoint != "tcp://127.0.0.1:4243" {
@@ -48,7 +48,7 @@ func TestDockerFlagEndpoint(t *testing.T) {
 	// flag value should override DOCKER_HOST and default value
 	endpoint, err := GetEndpoint("tcp://127.0.0.1:5555")
 	if err != nil {
-		t.Fatal("%s", err)
+		t.Fatalf("%s", err)
 	}
 	if endpoint != "tcp://127.0.0.1:5555" {
 		t.Fatalf("Expected tcp://127.0.0.1:5555, got %s", endpoint)


### PR DESCRIPTION
If a container uses the `network_mode: container:xxxx`, both the `.Networks` and `.Addresses` attributes are empty.

Making `NetworkMode` accessible will be a first step in resolving issue in  https://github.com/jwilder/nginx-proxy where people have to find workaround to alter the nginx .conf file to populate upstreams when they are routing their container network though an other container.


