### PR TITLE
Make sure file generated by docker-gen has the right permissions

### DIFF
--- a/template.go
+++ b/template.go
@@ -517,7 +517,16 @@ func GenerateFile(config Config, containers Context) bool {
 		}
 
 		oldContents := []byte{}
-		if fi, err := os.Stat(config.Dest); err == nil {
+		if fi, err := os.Stat(config.Dest); err == nil || os.IsNotExist(err) {
+			if (err != nil && os.IsNotExist(err)) {
+				emptyFile, err := os.Create(config.Dest)
+				if err != nil {
+					log.Fatalf("Unable to create empty destination file: %s\n", err)
+				} else {
+					emptyFile.Close()
+					fi, err = os.Stat(config.Dest)
+				}
+			}
 			if err := dest.Chmod(fi.Mode()); err != nil {
 				log.Fatalf("Unable to chmod temp file: %s\n", err)
 			}


### PR DESCRIPTION
If the destination file does not exists, the permissions become `600` because this is the default permission for temp files.

This is problematic, if the container consuming the destination file does not run as root.

Instead, the default permissions should be used (as per umask).
This PR will make permission `644`, which is generally what we want. And if the container consuming it is not happy with it, it always can override the permissions.