### PR TITLE
Improve notify-sigup to allow for the use of filters (such as labels)

### DIFF
--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -96,7 +96,7 @@ func initFlags() {
 	flag.BoolVar(&notifyOutput, "notify-output", false, "log the output(stdout/stderr) of notify command")
 	flag.StringVar(&notifyCmd, "notify", "", "run command after template is regenerated (e.g `restart xyz`)")
 	flag.StringVar(&notifySigHUPContainerID, "notify-sighup", "",
-		"send HUP signal to container.  Equivalent to docker kill -s HUP `container-ID`")
+		"send HUP signal to container. You can either pass a container name/id or a filter key=value to send to multiple containers. Equivalent to docker kill -s HUP `container-ID`")
 	flag.Var(&configFiles, "config", "config files with template directives. Config files will be merged if this option is specified multiple times.")
 	flag.IntVar(&interval, "interval", 0, "notify command interval (secs)")
 	flag.BoolVar(&keepBlankLines, "keep-blank-lines", false, "keep blank lines in the output file")

--- a/generator.go
+++ b/generator.go
@@ -340,7 +340,7 @@ func (g *generator) sendSignalToContainers(config Config) {
 	}
 	for container, signal := range config.NotifyContainers {
 		// Check if the input has a = (filter input requires key/value input) or default back to the old functionality
-		if filterSplit := strings.Split(container, "="); len(filterSplit) > 1 {
+		if filterSplit := strings.SplitN(container, "=", 2); len(filterSplit) > 1 {
 			filters := map[string][]string{}
 			filters[filterSplit[0]] = []string{filterSplit[1]}
 			listOpts := docker.ListContainersOptions{


### PR DESCRIPTION
This implementation will allow for the use of a filter to live query the containers before sending the sigup, and is fully backwards compatible with the previous implementation.

Resolves #77

