### PR TITLE
Support cgroup docker_limit.slice memory and cpu limits for docker daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docker-gen
 dist
 *.gz
+.idea

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -10,9 +10,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/mickelindahl/docker-gen"
-	//"github.com/jwilder/docker-gen"
-	//"../git/docker-gen"
+	"github.com/jwilder/docker-gen"
 )
 
 
@@ -118,12 +116,8 @@ func main() {
 
 	if version {
 
-		fmt.Println("hej")
 		fmt.Println(buildVersion)
 
-		container := dockergen.GetCurrentContainerID()
-
-		fmt.Println(container)
 		return
 	}
 

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jwilder/docker-gen"
 )
 
-
 type stringslice []string
 
 var (
@@ -115,9 +114,7 @@ func main() {
 	initFlags()
 
 	if version {
-
 		fmt.Println(buildVersion)
-
 		return
 	}
 

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -10,8 +10,11 @@ import (
 
 	"github.com/BurntSushi/toml"
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/jwilder/docker-gen"
+	"github.com/mickelindahl/docker-gen"
+	//"github.com/jwilder/docker-gen"
+	//"../git/docker-gen"
 )
+
 
 type stringslice []string
 
@@ -114,7 +117,13 @@ func main() {
 	initFlags()
 
 	if version {
+
+		fmt.Println("hej")
 		fmt.Println(buildVersion)
+
+		container := dockergen.GetCurrentContainerID()
+
+		fmt.Println(container)
 		return
 	}
 

--- a/context.go
+++ b/context.go
@@ -173,7 +173,6 @@ func GetCurrentContainerID() string {
 		_, lines, err := bufio.ScanLines([]byte(scanner.Text()), true)
 		if err == nil {
 			strLines := string(lines)
-
 			if id := matchDockerCurrentContainerID(strLines); id != "" {
 				return id
 			} else if id := matchECSCurrentContainerID(strLines); id != "" {
@@ -199,7 +198,6 @@ func matchDockerCurrentContainerID(lines string) string {
 	}
 	return ""
 }
-
 
 func matchECSCurrentContainerID(lines string) string {
 	regex := "/ecs\\/[^\\/]+\\/(.+)$"

--- a/context.go
+++ b/context.go
@@ -173,10 +173,6 @@ func GetCurrentContainerID() string {
 		_, lines, err := bufio.ScanLines([]byte(scanner.Text()), true)
 		if err == nil {
 			strLines := string(lines)
-			//strLines := "11:cpuacct,cpu:/docker_limit.slice/a23376d4f26b91bffc57b2c5622fe8eac1743e9e631ef911d0a139d7f8b123e7"
-			//fmt.Println(strLines)
-			//fmt.Println(matchDockerCurrentContainerID(strLines))
-			//fmt.Println(matchECSCurrentContainerID(strLines))
 
 			if id := matchDockerCurrentContainerID(strLines); id != "" {
 				return id

--- a/context.go
+++ b/context.go
@@ -173,9 +173,16 @@ func GetCurrentContainerID() string {
 		_, lines, err := bufio.ScanLines([]byte(scanner.Text()), true)
 		if err == nil {
 			strLines := string(lines)
+			//strLines := "11:cpuacct,cpu:/docker_limit.slice/a23376d4f26b91bffc57b2c5622fe8eac1743e9e631ef911d0a139d7f8b123e7"
+			//fmt.Println(strLines)
+			//fmt.Println(matchDockerCurrentContainerID(strLines))
+			//fmt.Println(matchECSCurrentContainerID(strLines))
+
 			if id := matchDockerCurrentContainerID(strLines); id != "" {
 				return id
 			} else if id := matchECSCurrentContainerID(strLines); id != "" {
+				return id
+			}else if id := matchDockerLimitCurrentContainerID(strLines); id != "" {
 				return id
 			}
 		}
@@ -197,8 +204,23 @@ func matchDockerCurrentContainerID(lines string) string {
 	return ""
 }
 
+
 func matchECSCurrentContainerID(lines string) string {
 	regex := "/ecs\\/[^\\/]+\\/(.+)$"
+	re := regexp.MustCompilePOSIX(regex)
+
+	if re.MatchString(string(lines)) {
+		submatches := re.FindStringSubmatch(string(lines))
+		containerID := submatches[1]
+
+		return containerID
+	}
+
+	return ""
+}
+
+func matchDockerLimitCurrentContainerID(lines string) string {
+	regex := "/docker[_-]limit.slice[/-]([[:alnum:]]{64})(\\.scope)?$"
 	re := regexp.MustCompilePOSIX(regex)
 
 	if re.MatchString(string(lines)) {


### PR DESCRIPTION
I had to restrict the total resources that the docker daemon can utilize on a server. The solution inlcuded adding a docker_limit.slice file to /etc/systemd/system (see https://github.com/mickelindahl/docker_daemon_limit_total_resources). This results in that in "/proc/self/cgroup" containers are named .../docker_limit.slice/{container id}. Thus matchDockerCurrentContainerID nor matchECSCurrentContainerID could pick up the container name which left me with a broken nginx-proxy. I have added an additional funcition matchDockerLimitCurrentContainerID witch solves this problem. Would love if you could add this to the project.

Cheers
/Mikael 