### PR TITLE
Explicitly make docker socket rw in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Fetch the template and start the docker-gen container with the shared volume:
 $ mkdir -p /tmp/templates && cd /tmp/templates
 $ curl -o nginx.tmpl https://raw.githubusercontent.com/jwilder/docker-gen/master/templates/nginx.tmpl
 $ docker run -d --name nginx-gen --volumes-from nginx \
-   -v /var/run/docker.sock:/tmp/docker.sock:ro \
+   -v /var/run/docker.sock:/tmp/docker.sock:rw \
    -v /tmp/templates:/etc/docker-gen/templates \
    -t jwilder/docker-gen -notify-sighup nginx -watch -only-exposed /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
 ```


### PR DESCRIPTION
Docker does not allow for read-only mounts of sockets at this point.
This can be tested by running:
```
❯ docker run --rm -it -v /var/run/docker.sock:/tmp/docker.sock:ro \
    docker ls -l /tmp/docker.sock
srw-rw----    1 root     967              0 Apr 13 16:16 /tmp/docker.sock
❯ docker run --rm -it -v /var/run/docker.sock:/tmp/docker.sock:ro \
    docker /usr/local/bin/docker -H unix:///tmp/docker.sock ps |wc -l
17
```

Even if docker supported read-only sockets, you would not want it to be
read-only if you are using `-notify-sighup` because then the docker socket is
used to communicate to the other container to notify it.

This change in documentation reflects the fact that the socket will be writable.