### PR TITLE
Additional tests and use of github.com/stretchr/testify/assert

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,43 @@
+package dockergen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseWait(t *testing.T) {
+	incorrectIntervals := []string{
+		"500x",    // Incorrect min interval
+		"500s:4x", // Incorrect max interval
+		"1m:1s",   // Min interval larger than max interval
+	}
+
+	for _, intervalString := range incorrectIntervals {
+		wait, err := ParseWait(intervalString)
+		assert.Error(t, err)
+		assert.Nil(t, wait)
+	}
+
+	correctIntervals := map[string]Wait{
+		"":          {0, 0},               // Empty time interval string
+		"1ms":       {1000000, 4000000},   // Correct min interval without max
+		"1ms:111ms": {1000000, 111000000}, // Correct min:max time interval
+	}
+
+	for intervalString, expectedWait := range correctIntervals {
+		wait, err := ParseWait(intervalString)
+		assert.NoError(t, err)
+		assert.Equal(t, &expectedWait, wait)
+	}
+}
+
+func TestWaitUnmarshalText(t *testing.T) {
+	// Correct min:max time interval
+	intervalBytes := []byte("1ms:2ms")
+	expectedWait := &Wait{1000000, 2000000}
+	wait := new(Wait)
+	err := wait.UnmarshalText(intervalBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedWait, wait)
+}

--- a/docker_client_test.go
+++ b/docker_client_test.go
@@ -2,195 +2,130 @@ package dockergen
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSplitDockerImageRepository(t *testing.T) {
 	registry, repository, tag := splitDockerImage("ubuntu")
 
-	if registry != "" {
-		t.Fail()
-	}
-	if repository != "ubuntu" {
-		t.Fail()
-	}
-	if tag != "" {
-		t.Fail()
-	}
+	assert.Equal(t, "", registry)
+	assert.Equal(t, "ubuntu", repository)
+	assert.Equal(t, "", tag)
 
 	dockerImage := DockerImage{
 		Registry:   registry,
 		Repository: repository,
 		Tag:        tag,
 	}
-	if "ubuntu" != dockerImage.String() {
-		t.Fail()
-	}
+	assert.Equal(t, "ubuntu", dockerImage.String())
 }
 
 func TestSplitDockerImageWithRegistry(t *testing.T) {
 	registry, repository, tag := splitDockerImage("custom.registry/ubuntu")
 
-	if registry != "custom.registry" {
-		t.Fail()
-	}
-	if repository != "ubuntu" {
-		t.Fail()
-	}
-	if tag != "" {
-		t.Fail()
-	}
+	assert.Equal(t, "custom.registry", registry)
+	assert.Equal(t, "ubuntu", repository)
+	assert.Equal(t, "", tag)
+
 	dockerImage := DockerImage{
 		Registry:   registry,
 		Repository: repository,
 		Tag:        tag,
 	}
-	if "custom.registry/ubuntu" != dockerImage.String() {
-		t.Fail()
-	}
-
+	assert.Equal(t, "custom.registry/ubuntu", dockerImage.String())
 }
 
 func TestSplitDockerImageWithRegistryAndTag(t *testing.T) {
 	registry, repository, tag := splitDockerImage("custom.registry/ubuntu:12.04")
 
-	if registry != "custom.registry" {
-		t.Fail()
-	}
-	if repository != "ubuntu" {
-		t.Fail()
-	}
-	if tag != "12.04" {
-		t.Fail()
-	}
+	assert.Equal(t, "custom.registry", registry)
+	assert.Equal(t, "ubuntu", repository)
+	assert.Equal(t, "12.04", tag)
+
 	dockerImage := DockerImage{
 		Registry:   registry,
 		Repository: repository,
 		Tag:        tag,
 	}
-	if "custom.registry/ubuntu:12.04" != dockerImage.String() {
-		t.Fail()
-	}
-
+	assert.Equal(t, "custom.registry/ubuntu:12.04", dockerImage.String())
 }
 
 func TestSplitDockerImageWithRepositoryAndTag(t *testing.T) {
 	registry, repository, tag := splitDockerImage("ubuntu:12.04")
 
-	if registry != "" {
-		t.Fail()
-	}
+	assert.Equal(t, "", registry)
+	assert.Equal(t, "ubuntu", repository)
+	assert.Equal(t, "12.04", tag)
 
-	if repository != "ubuntu" {
-		t.Fail()
-	}
-
-	if tag != "12.04" {
-		t.Fail()
-	}
 	dockerImage := DockerImage{
 		Registry:   registry,
 		Repository: repository,
 		Tag:        tag,
 	}
-	if "ubuntu:12.04" != dockerImage.String() {
-		t.Fail()
-	}
+	assert.Equal(t, "ubuntu:12.04", dockerImage.String())
 }
 
 func TestSplitDockerImageWithPrivateRegistryPath(t *testing.T) {
 	registry, repository, tag := splitDockerImage("localhost:8888/ubuntu/foo:12.04")
 
-	if registry != "localhost:8888" {
-		t.Fail()
-	}
+	assert.Equal(t, "localhost:8888", registry)
+	assert.Equal(t, "ubuntu/foo", repository)
+	assert.Equal(t, "12.04", tag)
 
-	if repository != "ubuntu/foo" {
-		t.Fail()
-	}
-
-	if tag != "12.04" {
-		t.Fail()
-	}
 	dockerImage := DockerImage{
 		Registry:   registry,
 		Repository: repository,
 		Tag:        tag,
 	}
-	if "localhost:8888/ubuntu/foo:12.04" != dockerImage.String() {
-		t.Fail()
-	}
+	assert.Equal(t, "localhost:8888/ubuntu/foo:12.04", dockerImage.String())
 }
 func TestSplitDockerImageWithLocalRepositoryAndTag(t *testing.T) {
 	registry, repository, tag := splitDockerImage("localhost:8888/ubuntu:12.04")
 
-	if registry != "localhost:8888" {
-		t.Fatalf("registry does not match: expected %s got %s", "localhost:8888", registry)
-	}
+	assert.Equal(t, "localhost:8888", registry)
+	assert.Equal(t, "ubuntu", repository)
+	assert.Equal(t, "12.04", tag)
 
-	if repository != "ubuntu" {
-		t.Fatalf("repository does not match: expected %s got %s", "ubuntu", repository)
-	}
-
-	if tag != "12.04" {
-		t.Fatalf("tag does not match: expected %s got %s", "12.04", tag)
-	}
 	dockerImage := DockerImage{
 		Registry:   registry,
 		Repository: repository,
 		Tag:        tag,
 	}
-	if "localhost:8888/ubuntu:12.04" != dockerImage.String() {
-		t.Fail()
-	}
-
+	assert.Equal(t, "localhost:8888/ubuntu:12.04", dockerImage.String())
 }
 
 func TestParseHostUnix(t *testing.T) {
 	proto, addr, err := parseHost("unix:///var/run/docker.sock")
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-	if proto != "unix" || addr != "/var/run/docker.sock" {
-		t.Fatal("failed to parse unix:///var/run/docker.sock")
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "unix", proto, "failed to parse unix:///var/run/docker.sock")
+	assert.Equal(t, "/var/run/docker.sock", addr, "failed to parse unix:///var/run/docker.sock")
 }
 
 func TestParseHostUnixDefault(t *testing.T) {
 	proto, addr, err := parseHost("")
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-	if proto != "unix" || addr != "/var/run/docker.sock" {
-		t.Fatal("failed to parse ''")
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "unix", proto, "failed to parse ''")
+	assert.Equal(t, "/var/run/docker.sock", addr, "failed to parse ''")
 }
 
 func TestParseHostUnixDefaultNoPath(t *testing.T) {
 	proto, addr, err := parseHost("unix://")
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-	if proto != "unix" || addr != "/var/run/docker.sock" {
-		t.Fatal("failed to parse unix://")
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "unix", proto, "failed to parse unix://")
+	assert.Equal(t, "/var/run/docker.sock", addr, "failed to parse unix://")
 }
 
 func TestParseHostTCP(t *testing.T) {
 	proto, addr, err := parseHost("tcp://127.0.0.1:4243")
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-	if proto != "tcp" || addr != "127.0.0.1:4243" {
-		t.Fatal("failed to parse tcp://127.0.0.1:4243")
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "tcp", proto, "failed to parse tcp://127.0.0.1:4243")
+	assert.Equal(t, "127.0.0.1:4243", addr, "failed to parse tcp://127.0.0.1:4243")
 }
 
 func TestParseHostTCPDefault(t *testing.T) {
 	proto, addr, err := parseHost("tcp://:4243")
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-	if proto != "tcp" || addr != "127.0.0.1:4243" {
-		t.Fatal("failed to parse unix:///var/run/docker.sock")
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "tcp", proto, "failed to parse tcp://:4243")
+	assert.Equal(t, "127.0.0.1:4243", addr, "failed to parse tcp://:4243")
 }

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/opencontainers/selinux v1.8.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54 // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 )

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -1,6 +1,10 @@
 package dockergen
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestDeepGetNoPath(t *testing.T) {
 	item := RuntimeContainer{}
@@ -21,13 +25,9 @@ func TestDeepGetSimple(t *testing.T) {
 		ID: "expected",
 	}
 	value := deepGet(item, "ID")
-	if _, ok := value.(string); !ok {
-		t.Errorf("expected: %#v. got: %#v", "expected", value)
-	}
+	assert.IsType(t, "", value)
 
-	if value != "expected" {
-		t.Errorf("expected: %s. got: %s", "expected", value)
-	}
+	assert.Equal(t, "expected", value)
 }
 
 func TestDeepGetSimpleDotPrefix(t *testing.T) {
@@ -35,13 +35,9 @@ func TestDeepGetSimpleDotPrefix(t *testing.T) {
 		ID: "expected",
 	}
 	value := deepGet(item, "...ID")
-	if _, ok := value.(string); !ok {
-		t.Errorf("expected: %#v. got: %#v", "expected", value)
-	}
+	assert.IsType(t, "", value)
 
-	if value != "expected" {
-		t.Errorf("expected: %s. got: %s", "expected", value)
-	}
+	assert.Equal(t, "expected", value)
 }
 
 func TestDeepGetMap(t *testing.T) {
@@ -51,11 +47,7 @@ func TestDeepGetMap(t *testing.T) {
 		},
 	}
 	value := deepGet(item, "Env.key")
-	if _, ok := value.(string); !ok {
-		t.Errorf("expected: %#v. got: %#v", "value", value)
-	}
+	assert.IsType(t, "", value)
 
-	if value != "value" {
-		t.Errorf("expected: %s. got: %s", "value", value)
-	}
+	assert.Equal(t, "value", value)
 }


### PR DESCRIPTION
Additional tests for `config.go` and `docker_client.go`, plus making use of `github.com/stretchr/testify/assert` (which is already an indirect dependency).

Test coverage bump from 63.8% to 67.6%, yay.