### PR TITLE
Additional tests and incremental enhancements

### DIFF
--- a/internal/dockergen/context_test.go
+++ b/internal/dockergen/context_test.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -86,16 +88,12 @@ func TestGetCurrentContainerID(t *testing.T) {
 	// Each time the HOSTNAME is set to a short form ID, GetCurrentContainerID() should match and return the corresponding full ID
 	for _, id := range ids {
 		os.Setenv("HOSTNAME", id[0:12])
-		if got, exp := GetCurrentContainerID(filepaths...), id; got != exp {
-			t.Fatalf("id mismatch with HOSTNAME %v: got %v, exp %v", id[0:12], got, exp)
-		}
+		assert.Equal(t, id, GetCurrentContainerID(filepaths...), "id mismatch with default HOSTNAME")
 	}
 
 	// If the Hostname isn't a short form ID, we should match the first valid ID (64 character hex string) instead
 	os.Setenv("HOSTNAME", "customhostname")
-	if got, exp := GetCurrentContainerID(filepaths...), ids[0]; got != exp {
-		t.Fatalf("id mismatch with custom HOSTNAME: got %v, exp %v", got, exp)
-	}
+	assert.Equal(t, ids[0], GetCurrentContainerID(filepaths...), "id mismatch with custom HOSTNAME")
 }
 
 func TestGetCurrentContainerIDMountInfo(t *testing.T) {
@@ -128,7 +126,5 @@ func TestGetCurrentContainerIDMountInfo(t *testing.T) {
 	}
 
 	// We should match the correct 64 characters long ID in mountinfo, not the first encountered
-	if got, exp := GetCurrentContainerID(filepaths...), id; got != exp {
-		t.Fatalf("id mismatch on mountinfo: got %v, exp %v", got, exp)
-	}
+	assert.Equal(t, id, GetCurrentContainerID(filepaths...), "id mismatch on mountinfo")
 }

--- a/internal/dockergen/context_test.go
+++ b/internal/dockergen/context_test.go
@@ -3,7 +3,6 @@ package dockergen
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"testing"
 )
@@ -75,11 +74,11 @@ func TestGetCurrentContainerID(t *testing.T) {
 	for _, key := range fileKeys {
 		file, err := ioutil.TempFile("", key)
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 		defer os.Remove(file.Name())
 		if _, err = file.WriteString(contents[key]); err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 		filepaths = append(filepaths, file.Name())
 	}
@@ -119,11 +118,11 @@ func TestGetCurrentContainerIDMountInfo(t *testing.T) {
 	for _, key := range fileKeys {
 		file, err := ioutil.TempFile("", key)
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 		defer os.Remove(file.Name())
 		if _, err = file.WriteString(content[key]); err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 		filepaths = append(filepaths, file.Name())
 	}

--- a/internal/dockergen/context_test.go
+++ b/internal/dockergen/context_test.go
@@ -128,3 +128,38 @@ func TestGetCurrentContainerIDMountInfo(t *testing.T) {
 	// We should match the correct 64 characters long ID in mountinfo, not the first encountered
 	assert.Equal(t, id, GetCurrentContainerID(filepaths...), "id mismatch on mountinfo")
 }
+
+func TestGetCurrentContainerEmpty(t *testing.T) {
+	assert.Equal(t, "", GetCurrentContainerID())
+}
+
+func TestPublishedAddresses(t *testing.T) {
+	container := &RuntimeContainer{
+		Addresses: []Address{
+			{
+				IP:       "172.19.0.1",
+				HostPort: "80",
+			},
+			{
+				IP: "172.19.0.2",
+			},
+			{
+				IP:       "172.19.0.3",
+				HostPort: "8080",
+			},
+		},
+	}
+
+	expected := []Address{
+		{
+			IP:       "172.19.0.1",
+			HostPort: "80",
+		},
+		{
+			IP:       "172.19.0.3",
+			HostPort: "8080",
+		},
+	}
+
+	assert.ElementsMatch(t, expected, container.PublishedAddresses())
+}

--- a/internal/dockergen/docker_client_test.go
+++ b/internal/dockergen/docker_client_test.go
@@ -3,7 +3,6 @@ package dockergen
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"testing"
 
@@ -182,7 +181,7 @@ func TestTlsEnabled(t *testing.T) {
 	for key := range filepaths {
 		file, err := ioutil.TempFile("", key)
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 		defer os.Remove(file.Name())
 		filepaths[key] = file.Name()

--- a/internal/dockergen/template_test.go
+++ b/internal/dockergen/template_test.go
@@ -38,6 +38,25 @@ func (tests templateTestList) run(t *testing.T, prefix string) {
 	}
 }
 
+func TestGetArrayValues(t *testing.T) {
+	values := []string{"foor", "bar", "baz"}
+	var expectedType *reflect.Value
+
+	arrayValues, err := getArrayValues("testFunc", values)
+	assert.NoError(t, err)
+	assert.IsType(t, expectedType, arrayValues)
+	assert.Equal(t, "bar", arrayValues.Index(1).String())
+
+	arrayValues, err = getArrayValues("testFunc", &values)
+	assert.NoError(t, err)
+	assert.IsType(t, expectedType, arrayValues)
+	assert.Equal(t, "baz", arrayValues.Index(2).String())
+
+	arrayValues, err = getArrayValues("testFunc", "foo")
+	assert.Error(t, err)
+	assert.Nil(t, arrayValues)
+}
+
 func TestContainsString(t *testing.T) {
 	env := map[string]string{
 		"PORT": "1234",


### PR DESCRIPTION
- additional tests for `template.go` and `context.go`
- continued use of `github.com/stretchr/testify/assert` where relevant
- replacement of `log.Fatal()` calls with `testing.T.Fatal()` calls in the tests