### PR TITLE
Fix exit(2) on SIGHUP before fully initialized.

### DIFF
--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 
 	"github.com/BurntSushi/toml"
 	docker "github.com/fsouza/go-dockerclient"
@@ -113,6 +115,10 @@ func initFlags() {
 }
 
 func main() {
+	// SIGHUP is used to trigger generation but go programs call os.Exit(2) at default.
+	// Ignore the signal until the handler is registered:
+	signal.Ignore(syscall.SIGHUP)
+
 	initFlags()
 
 	if version {


### PR DESCRIPTION
docker-gen uses SIGHUP to trigger regeneration.
However, when SIGHUP is fired before docker-gen is fully initialized (and the signal handler was installed), the process will just exit(2).
This fix ignores SIGHUP until the signal handler is installed.

Fixes https://github.com/jwilder/docker-gen/issues/244