### PR TITLE
Set DOCKER_GEN_VERSION in Docker image env

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -94,7 +94,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          build-args: VERSION=${{ env.GIT_DESCRIBE }}
+          build-args: DOCKER_GEN_VERSION=${{ env.GIT_DESCRIBE }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.docker_meta_alpine.outputs.tags }}
@@ -106,7 +106,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          build-args: VERSION=${{ env.GIT_DESCRIBE }}
+          build-args: DOCKER_GEN_VERSION=${{ env.GIT_DESCRIBE }}
           file: Dockerfile.debian
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
+ARG DOCKER_GEN_VERSION=main
+
 # Build docker-gen from scratch
 FROM golang:1.17.8-alpine as go-builder
 
-ARG VERSION=main
-
+ARG DOCKER_GEN_VERSION
 WORKDIR /build
 
 # Install the dependencies
@@ -10,11 +11,13 @@ COPY . .
 RUN go mod download
 
 # Build the docker-gen executable
-RUN GOOS=linux CGO_ENABLED=0 go build -ldflags "-X main.buildVersion=${VERSION}" -o docker-gen ./cmd/docker-gen
+RUN GOOS=linux CGO_ENABLED=0 go build -ldflags "-X main.buildVersion=${DOCKER_GEN_VERSION}" -o docker-gen ./cmd/docker-gen
 
 FROM alpine:3.15.0
 
-ENV DOCKER_HOST unix:///tmp/docker.sock
+ARG DOCKER_GEN_VERSION
+ENV DOCKER_GEN_VERSION=${DOCKER_GEN_VERSION} \
+    DOCKER_HOST=unix:///tmp/docker.sock
 
 # Install packages required by the image
 RUN apk add --no-cache --virtual .bin-deps openssl

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,7 +1,9 @@
+ARG DOCKER_GEN_VERSION=main
+
 # Build docker-gen from scratch
 FROM golang:1.17.8 as go-builder
 
-ARG VERSION=main
+ARG DOCKER_GEN_VERSION
 
 WORKDIR /build
 
@@ -10,11 +12,13 @@ COPY . .
 RUN go mod download
 
 # Build the docker-gen executable
-RUN GOOS=linux go build -ldflags "-X main.buildVersion=${VERSION}" -o docker-gen ./cmd/docker-gen
+RUN GOOS=linux go build -ldflags "-X main.buildVersion=${DOCKER_GEN_VERSION}" -o docker-gen ./cmd/docker-gen
 
 FROM debian:11.2-slim
 
-ENV DOCKER_HOST unix:///tmp/docker.sock
+ARG VERSION
+ENV DOCKER_GEN_VERSION=${VERSION} \
+    DOCKER_HOST=unix:///tmp/docker.sock
 
 # Install packages required by the image
 RUN apt-get update \


### PR DESCRIPTION
This PR set the `DOCKER_GEN_VERSION` environment variable inside the Docker images.