### PR TITLE
Build and upload GitHub release assets in GitHub Actions

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -1,0 +1,29 @@
+name: Release assets
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  assets:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      
+      - name: Build release assets
+        run: make release
+      
+      - name: Upload release assets
+        uses: alexellis/upload-assets@0.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_paths: '["./docker-gen-*.tar.gz"]'
+      
+      - name: Cleanup release assets
+        run: make dist-clean


### PR DESCRIPTION
This PR add a GitHub Actions workflow that build and upload assets (binaries in .tar.gz) to the corresponding GitHub release when a new one is published.