### PR TITLE
Add template functions from sprig

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ e75a60548dc9 = 1  # a key can be either container name (nginx) or ID
 
 ### Templating
 
-The templates used by docker-gen are written using the Go [text/template](http://golang.org/pkg/text/template/) language. In addition to the [built-in functions](http://golang.org/pkg/text/template/#hdr-Functions) supplied by Go, docker-gen provides a number of additional functions to make it simpler (or possible) to generate your desired output.
+The templates used by docker-gen are written using the Go [text/template](http://golang.org/pkg/text/template/) language. In addition to the [built-in functions](http://golang.org/pkg/text/template/#hdr-Functions) supplied by Go, docker-gen uses [sprig](https://masterminds.github.io/sprig/) and some additional functions to make it simpler (or possible) to generate your desired output.
 
 #### Emit Structure
 
@@ -354,23 +354,20 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 
 #### Functions
 
+* [Functions from Go](https://pkg.go.dev/text/template#hdr-Functions)
+* [Functions from Sprig v3](https://masterminds.github.io/sprig/), except for those that have the same name as one of the following functions.
 * *`closest $array $value`*: Returns the longest matching substring in `$array` that matches `$value`
 * *`coalesce ...`*: Returns the first non-nil argument.
 * *`contains $map $key`*: Returns `true` if `$map` contains `$key`. Takes maps from `string` to any type.
-* *`dict $key $value ...`*: Creates a map from a list of pairs. Each `$key` value must be a `string`, but the `$value` can be any type (or `nil`). Useful for passing more than one value as a pipeline context to subtemplates.
 * *`dir $path`*: Returns an array of filenames in the specified `$path`.
 * *`exists $path`*: Returns `true` if `$path` refers to an existing file or directory. Takes a string.
-* *`first $array`*: Returns the first value of an array or nil if the arry is nil or empty.
 * *`groupBy $containers $fieldPath`*: Groups an array of `RuntimeContainer` instances based on the values of a field path expression `$fieldPath`. A field path expression is a dot-delimited list of map keys or struct member names specifying the path from container to a nested value, which must be a string. Returns a map from the value of the field path expression to an array of containers having that value. Containers that do not have a value for the field path in question are omitted.
 * *`groupByKeys $containers $fieldPath`*: Returns the same as `groupBy` but only returns the keys of the map.
 * *`groupByMulti $containers $fieldPath $sep`*: Like `groupBy`, but the string value specified by `$fieldPath` is first split by `$sep` into a list of strings. A container whose `$fieldPath` value contains a list of strings will show up in the map output under each of those strings.
 * *`groupByLabel $containers $label`*: Returns the same as `groupBy` but grouping by the given label's value.
-* *`hasPrefix $prefix $string`*: Returns whether `$prefix` is a prefix of `$string`.
-* *`hasSuffix $suffix $string`*: Returns whether `$suffix` is a suffix of `$string`.
 * *`intersect $slice1 $slice2`*: Returns the strings that exist in both string slices.
 * *`json $value`*: Returns the JSON representation of `$value` as a `string`.
 * *`keys $map`*: Returns the keys from `$map`. If `$map` is `nil`, a `nil` is returned. If `$map` is not a `map`, an error will be thrown.
-* *`last $array`*: Returns the last value of an array.
 * *`parseBool $string`*: parseBool returns the boolean value represented by the string. It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False. Any other value returns an error. Alias for [`strconv.ParseBool`](http://golang.org/pkg/strconv/#ParseBool) 
 * *`replace $string $old $new $count`*: Replaces up to `$count` occurences of `$old` with `$new` in `$string`. Alias for [`strings.Replace`](http://golang.org/pkg/strings/#Replace)
 * *`sha1 $string`*: Returns the hexadecimal representation of the SHA1 hash of `$string`.
@@ -382,7 +379,6 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 * *`sortObjectsByKeysDesc $objects $fieldPath`: Returns the array `$objects`, sorted in descending (reverse) order based on the values of a field path expression `$fieldPath`.
 * *`trimPrefix $prefix $string`*: If `$prefix` is a prefix of `$string`, return `$string` with `$prefix` trimmed from the beginning. Otherwise, return `$string` unchanged.
 * *`trimSuffix $suffix $string`*: If `$suffix` is a suffix of `$string`, return `$string` with `$suffix` trimmed from the end. Otherwise, return `$string` unchanged.
-* *`trim $string`*: Removes whitespace from both sides of `$string`.
 * *`toLower $string`*: Replace capital letters in `$string` to lowercase.
 * *`toUpper $string`*: Replace lowercase letters in `$string` to uppercase.
 * *`when $condition $trueValue $falseValue`*: Returns the `$trueValue` when the `$condition` is `true` and the `$falseValue` otherwise

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/BurntSushi/toml v1.0.0
+	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/fsouza/go-dockerclient v1.7.10
 	github.com/stretchr/testify v1.7.1
 )
@@ -12,7 +13,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
-	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/Microsoft/hcsshim v0.9.2 // indirect
 	github.com/containerd/cgroups v1.0.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,9 @@ require (
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/Microsoft/hcsshim v0.9.2 // indirect
 	github.com/containerd/cgroups v1.0.3 // indirect
@@ -20,7 +23,12 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/google/uuid v1.2.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/huandu/xstrings v1.3.1 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/moby/sys/mount v0.2.0 // indirect
 	github.com/moby/sys/mountinfo v0.5.0 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
@@ -30,8 +38,11 @@ require (
 	github.com/opencontainers/runc v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1361,6 +1361,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,12 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.0.0 h1:dtDWrepsVPfW9H/4y7dDgFc2MBUSeJhlaDtK13CxFlU=
 github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/Masterminds/sprig/v3 v3.2.2 h1:17jRggJu518dr3QaafizSXOjKYp94wKfABxUmyxvxX8=
+github.com/Masterminds/sprig/v3 v3.2.2/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
@@ -468,6 +474,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -516,12 +523,15 @@ github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0m
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs=
+github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
@@ -586,6 +596,8 @@ github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3N
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
+github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
+github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
@@ -594,6 +606,8 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
+github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
+github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mount v0.2.0 h1:WhCW5B355jtxndN5ovugJlMFJawbUODuW8fSnEH6SSM=
@@ -740,6 +754,8 @@ github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
+github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
+github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
@@ -759,6 +775,8 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
+github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
@@ -884,11 +902,13 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/internal/template/functions.go
+++ b/internal/template/functions.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,16 +11,6 @@ import (
 	"reflect"
 	"strings"
 )
-
-// hasPrefix returns whether a given string is a prefix of another string
-func hasPrefix(prefix, s string) bool {
-	return strings.HasPrefix(s, prefix)
-}
-
-// hasSuffix returns whether a given string is a suffix of another string
-func hasSuffix(suffix, s string) bool {
-	return strings.HasSuffix(s, suffix)
-}
 
 func keys(input interface{}) (interface{}, error) {
 	if input == nil {
@@ -77,21 +66,6 @@ func contains(input interface{}, key interface{}) bool {
 	return false
 }
 
-func dict(values ...interface{}) (map[string]interface{}, error) {
-	if len(values)%2 != 0 {
-		return nil, errors.New("invalid dict call")
-	}
-	dict := make(map[string]interface{}, len(values)/2)
-	for i := 0; i < len(values); i += 2 {
-		key, ok := values[i].(string)
-		if !ok {
-			return nil, errors.New("dict keys must be strings")
-		}
-		dict[key] = values[i+1]
-	}
-	return dict, nil
-}
-
 func hashSha1(input string) string {
 	h := sha1.New()
 	io.WriteString(h, input)
@@ -113,28 +87,6 @@ func unmarshalJson(input string) (interface{}, error) {
 		return nil, err
 	}
 	return v, nil
-}
-
-// arrayFirst returns first item in the array or nil if the
-// input is nil or empty
-func arrayFirst(input interface{}) interface{} {
-	if input == nil {
-		return nil
-	}
-
-	arr := reflect.ValueOf(input)
-
-	if arr.Len() == 0 {
-		return nil
-	}
-
-	return arr.Index(0).Interface()
-}
-
-// arrayLast returns last item in the array
-func arrayLast(input interface{}) interface{} {
-	arr := reflect.ValueOf(input)
-	return arr.Index(arr.Len() - 1).Interface()
 }
 
 // arrayClosest find the longest matching substring in values
@@ -181,11 +133,6 @@ func trimPrefix(prefix, s string) string {
 // trimSuffix returns a string without the suffix, if present
 func trimSuffix(suffix, s string) string {
 	return strings.TrimSuffix(s, suffix)
-}
-
-// trim returns the string without leading or trailing whitespace
-func trim(s string) string {
-	return strings.TrimSpace(s)
 }
 
 // toLower return the string in lower case

--- a/internal/template/functions_test.go
+++ b/internal/template/functions_test.go
@@ -47,7 +47,7 @@ func TestKeys(t *testing.T) {
 		{`{{range (keys $)}}{{.}}{{end}}`, env, `VIRTUAL_HOST`},
 	}
 
-	tests.run(t, "keys")
+	tests.run(t)
 }
 
 func TestKeysEmpty(t *testing.T) {
@@ -116,7 +116,7 @@ func TestSplitN(t *testing.T) {
 		{`{{len (splitN . "/" 2)}}`, "example.com", `1`},
 	}
 
-	tests.run(t, "splitN")
+	tests.run(t)
 }
 
 func TestTrimPrefix(t *testing.T) {
@@ -250,7 +250,7 @@ func TestParseJson(t *testing.T) {
 		{`{{index (parseJson . | first) "enabled"}}`, `[{"enabled":true}]`, `true`},
 	}
 
-	tests.run(t, "parseJson")
+	tests.run(t)
 }
 
 func TestQueryEscape(t *testing.T) {
@@ -261,7 +261,7 @@ func TestQueryEscape(t *testing.T) {
 		{`{{queryEscape .}}`, `~^example\.com(\..*\.xip\.io)?$`, `~%5Eexample%5C.com%28%5C..%2A%5C.xip%5C.io%29%3F%24`},
 	}
 
-	tests.run(t, "queryEscape")
+	tests.run(t)
 }
 
 func TestArrayClosestExact(t *testing.T) {
@@ -299,7 +299,7 @@ func TestWhen(t *testing.T) {
 		{`{{ when (not (eq .StringValue "foo")) "first" "second" | print }}`, context, `second`},
 	}
 
-	tests.run(t, "when")
+	tests.run(t)
 }
 
 func TestWhenTrue(t *testing.T) {

--- a/internal/template/functions_test.go
+++ b/internal/template/functions_test.go
@@ -92,22 +92,6 @@ func TestIntersect(t *testing.T) {
 	assert.Len(t, i, 2, "Expected exactly two matches")
 }
 
-func TestHasPrefix(t *testing.T) {
-	const prefix = "tcp://"
-	const str = "tcp://127.0.0.1:2375"
-	if !hasPrefix(prefix, str) {
-		t.Fatalf("expected %s to have prefix %s", str, prefix)
-	}
-}
-
-func TestHasSuffix(t *testing.T) {
-	const suffix = ".local"
-	const str = "myhost.local"
-	if !hasSuffix(suffix, str) {
-		t.Fatalf("expected %s to have suffix %s", str, suffix)
-	}
-}
-
 func TestSplitN(t *testing.T) {
 	tests := templateTestList{
 		{`{{index (splitN . "/" 2) 0}}`, "example.com/path", `example.com`},
@@ -139,15 +123,6 @@ func TestTrimSuffix(t *testing.T) {
 	}
 }
 
-func TestTrim(t *testing.T) {
-	const str = "  myhost.local  "
-	const trimmed = "myhost.local"
-	got := trim(str)
-	if got != trimmed {
-		t.Fatalf("expected trim(%s) to be %s, got %s", str, trimmed, got)
-	}
-}
-
 func TestToLower(t *testing.T) {
 	const str = ".RaNd0m StrinG_"
 	const lowered = ".rand0m string_"
@@ -158,39 +133,6 @@ func TestToUpper(t *testing.T) {
 	const str = ".RaNd0m StrinG_"
 	const uppered = ".RAND0M STRING_"
 	assert.Equal(t, uppered, toUpper(str), "Unexpected value from toUpper()")
-}
-
-func TestDict(t *testing.T) {
-	containers := []*context.RuntimeContainer{
-		{
-			Env: map[string]string{
-				"VIRTUAL_HOST": "demo1.localhost",
-			},
-			ID: "1",
-		},
-		{
-			Env: map[string]string{
-				"VIRTUAL_HOST": "demo1.localhost,demo3.localhost",
-			},
-			ID: "2",
-		},
-		{
-			Env: map[string]string{
-				"VIRTUAL_HOST": "demo2.localhost",
-			},
-			ID: "3",
-		},
-	}
-	d, err := dict("/", containers)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if d["/"] == nil {
-		t.Fatalf("did not find containers in dict: %s", d)
-	}
-	if d["MISSING"] != nil {
-		t.Fail()
-	}
 }
 
 func TestSha1(t *testing.T) {

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -17,6 +17,7 @@ import (
 	"text/template"
 	"unicode"
 
+	sprig "github.com/Masterminds/sprig/v3"
 	"github.com/nginx-proxy/docker-gen/internal/config"
 	"github.com/nginx-proxy/docker-gen/internal/context"
 	"github.com/nginx-proxy/docker-gen/internal/utils"
@@ -42,24 +43,19 @@ func getArrayValues(funcName string, entries interface{}) (*reflect.Value, error
 }
 
 func newTemplate(name string) *template.Template {
-	tmpl := template.New(name).Funcs(template.FuncMap{
+	tmpl := template.New(name).Funcs(sprig.TxtFuncMap()).Funcs(template.FuncMap{
 		"closest":                arrayClosest,
 		"coalesce":               coalesce,
 		"contains":               contains,
-		"dict":                   dict,
 		"dir":                    dirList,
 		"exists":                 utils.PathExists,
-		"first":                  arrayFirst,
 		"groupBy":                groupBy,
 		"groupByKeys":            groupByKeys,
 		"groupByMulti":           groupByMulti,
 		"groupByLabel":           groupByLabel,
-		"hasPrefix":              hasPrefix,
-		"hasSuffix":              hasSuffix,
 		"json":                   marshalJson,
 		"intersect":              intersect,
 		"keys":                   keys,
-		"last":                   arrayLast,
 		"replace":                strings.Replace,
 		"parseBool":              strconv.ParseBool,
 		"parseJson":              unmarshalJson,
@@ -73,7 +69,6 @@ func newTemplate(name string) *template.Template {
 		"sortObjectsByKeysDesc":  sortObjectsByKeysDesc,
 		"trimPrefix":             trimPrefix,
 		"trimSuffix":             trimSuffix,
-		"trim":                   trim,
 		"toLower":                toLower,
 		"toUpper":                toUpper,
 		"when":                   when,

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -19,8 +19,10 @@ type templateTestList []struct {
 
 func (tests templateTestList) run(t *testing.T, prefix string) {
 	for n, test := range tests {
+		test := test
 		tmplName := fmt.Sprintf("%s-test-%d", prefix, n)
 		t.Run(tmplName, func(t *testing.T) {
+			t.Parallel()
 			tmpl := template.Must(newTemplate(tmplName).Parse(test.tmpl))
 
 			var b bytes.Buffer

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -20,18 +20,20 @@ type templateTestList []struct {
 func (tests templateTestList) run(t *testing.T, prefix string) {
 	for n, test := range tests {
 		tmplName := fmt.Sprintf("%s-test-%d", prefix, n)
-		tmpl := template.Must(newTemplate(tmplName).Parse(test.tmpl))
+		t.Run(tmplName, func(t *testing.T) {
+			tmpl := template.Must(newTemplate(tmplName).Parse(test.tmpl))
 
-		var b bytes.Buffer
-		err := tmpl.ExecuteTemplate(&b, tmplName, test.context)
-		if err != nil {
-			t.Fatalf("Error executing template: %v (test %s)", err, tmplName)
-		}
+			var b bytes.Buffer
+			err := tmpl.ExecuteTemplate(&b, tmplName, test.context)
+			if err != nil {
+				t.Fatalf("Error executing template: %v (test %s)", err, tmplName)
+			}
 
-		got := b.String()
-		if test.expected != got {
-			t.Fatalf("Incorrect output found; expected %s, got %s (test %s)", test.expected, got, tmplName)
-		}
+			got := b.String()
+			if test.expected != got {
+				t.Fatalf("Incorrect output found; expected %s, got %s (test %s)", test.expected, got, tmplName)
+			}
+		})
 	}
 }
 

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -2,11 +2,10 @@ package template
 
 import (
 	"bytes"
-	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
-	"text/template"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -17,23 +16,22 @@ type templateTestList []struct {
 	expected string
 }
 
-func (tests templateTestList) run(t *testing.T, prefix string) {
+func (tests templateTestList) run(t *testing.T) {
 	for n, test := range tests {
 		test := test
-		tmplName := fmt.Sprintf("%s-test-%d", prefix, n)
-		t.Run(tmplName, func(t *testing.T) {
+		t.Run(strconv.Itoa(n), func(t *testing.T) {
 			t.Parallel()
-			tmpl := template.Must(newTemplate(tmplName).Parse(test.tmpl))
+			tmpl := template.Must(newTemplate("testTemplate").Parse(test.tmpl))
 
 			var b bytes.Buffer
-			err := tmpl.ExecuteTemplate(&b, tmplName, test.context)
+			err := tmpl.ExecuteTemplate(&b, "testTemplate", test.context)
 			if err != nil {
-				t.Fatalf("Error executing template: %v (test %s)", err, tmplName)
+				t.Fatalf("Error executing template: %v", err)
 			}
 
 			got := b.String()
 			if test.expected != got {
-				t.Fatalf("Incorrect output found; expected %s, got %s (test %s)", test.expected, got, tmplName)
+				t.Fatalf("Incorrect output found; expected %s, got %s", test.expected, got)
 			}
 		})
 	}

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -21,10 +21,13 @@ func (tests templateTestList) run(t *testing.T) {
 		test := test
 		t.Run(strconv.Itoa(n), func(t *testing.T) {
 			t.Parallel()
-			tmpl := template.Must(newTemplate("testTemplate").Parse(test.tmpl))
+			tmpl, err := newTemplate("testTemplate").Parse(test.tmpl)
+			if err != nil {
+				t.Fatalf("Template parse failed: %v", err)
+			}
 
 			var b bytes.Buffer
-			err := tmpl.ExecuteTemplate(&b, "testTemplate", test.context)
+			err = tmpl.ExecuteTemplate(&b, "testTemplate", test.context)
 			if err != nil {
 				t.Fatalf("Error executing template: %v", err)
 			}

--- a/internal/template/where_test.go
+++ b/internal/template/where_test.go
@@ -68,7 +68,7 @@ func TestWhere(t *testing.T) {
 		},
 	}
 
-	tests.run(t, "where")
+	tests.run(t)
 }
 
 func TestWhereNot(t *testing.T) {
@@ -133,7 +133,7 @@ func TestWhereNot(t *testing.T) {
 		},
 	}
 
-	tests.run(t, "whereNot")
+	tests.run(t)
 }
 
 func TestWhereExist(t *testing.T) {
@@ -173,7 +173,7 @@ func TestWhereExist(t *testing.T) {
 		{`{{whereExist . "Env.VIRTUAL_PROTO" | len}}`, containers, `1`},
 	}
 
-	tests.run(t, "whereExist")
+	tests.run(t)
 }
 
 func TestWhereNotExist(t *testing.T) {
@@ -213,7 +213,7 @@ func TestWhereNotExist(t *testing.T) {
 		{`{{whereNotExist . "Env.VIRTUAL_PROTO" | len}}`, containers, `3`},
 	}
 
-	tests.run(t, "whereNotExist")
+	tests.run(t)
 }
 
 func TestWhereSomeMatch(t *testing.T) {
@@ -251,7 +251,7 @@ func TestWhereSomeMatch(t *testing.T) {
 		{`{{whereAny . "Env.NOEXIST" "," (split "demo3.localhost" ",") | len}}`, containers, `0`},
 	}
 
-	tests.run(t, "whereAny")
+	tests.run(t)
 }
 
 func TestWhereRequires(t *testing.T) {
@@ -289,7 +289,7 @@ func TestWhereRequires(t *testing.T) {
 		{`{{whereAll . "Env.NOEXIST" "," (split "demo3.localhost" ",") | len}}`, containers, `0`},
 	}
 
-	tests.run(t, "whereAll")
+	tests.run(t)
 }
 
 func TestWhereLabelExists(t *testing.T) {
@@ -315,7 +315,7 @@ func TestWhereLabelExists(t *testing.T) {
 		{`{{whereLabelExists . "com.example.baz" | len}}`, containers, `0`},
 	}
 
-	tests.run(t, "whereLabelExists")
+	tests.run(t)
 }
 
 func TestWhereLabelDoesNotExist(t *testing.T) {
@@ -341,7 +341,7 @@ func TestWhereLabelDoesNotExist(t *testing.T) {
 		{`{{whereLabelDoesNotExist . "com.example.baz" | len}}`, containers, `2`},
 	}
 
-	tests.run(t, "whereLabelDoesNotExist")
+	tests.run(t)
 }
 
 func TestWhereLabelValueMatches(t *testing.T) {
@@ -370,5 +370,5 @@ func TestWhereLabelValueMatches(t *testing.T) {
 		{`{{whereLabelValueMatches . "com.example.baz" ".*" | len}}`, containers, `0`},
 	}
 
-	tests.run(t, "whereLabelValueMatches")
+	tests.run(t)
 }


### PR DESCRIPTION
This PR adds a bunch of useful template functions from the [sprig library](https://masterminds.github.io/sprig/), which makes it easier/possible to introduce more advanced logic in templates.

Fixes #177 by adding useful functions like `append`, `join`, and `set`.

Fixes #293 by enabling templates to use a Go map object as a set (via the `set` and `hasKey` functions).

Fixes #323 by adding a new `getHostByName` function.

The removed functions were removed because sprig offers those same functions with the same behavior. I left functions with the same name but different behavior alone to avoid breaking existing templates. 