### PR TITLE
Bump Go version to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG DOCKER_GEN_VERSION=main
 
 # Build docker-gen from scratch
-FROM golang:1.17.8-alpine as go-builder
+FROM golang:1.18.0-alpine as go-builder
 
 ARG DOCKER_GEN_VERSION
 WORKDIR /build

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,7 +1,7 @@
 ARG DOCKER_GEN_VERSION=main
 
 # Build docker-gen from scratch
-FROM golang:1.17.8 as go-builder
+FROM golang:1.18.0 as go-builder
 
 ARG DOCKER_GEN_VERSION
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nginx-proxy/docker-gen
 
-go 1.17
+go 1.18
 
 require (
 	github.com/BurntSushi/toml v1.1.0


### PR DESCRIPTION
This PR bump Go version to `1.18`.

Noteworthy addition are the `break` and `continue` actions in `text/template` (thanks @rhansen for highlighting this):

> `{{break}}`
> 	The innermost `{{range pipeline}}` loop is ended early, stopping the
> 	current iteration and bypassing all remaining iterations.
> 
> `{{continue}}`
> 	The current iteration of the innermost `{{range pipeline}}` loop is
> 	stopped, and the loop starts the next iteration.