### PR TITLE
added support to use label for notify-sigup instead of container name

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,27 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Docker Login
+      env:
+        DOCKER_USER: ${{secrets.DOCKER_USER}}
+        DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+      run: |
+        docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag ${{secrets.DOCKER_USER}}/docker-gen:$(date +%s)
+    - name: Docker Push
+      run: docker push ${{secrets.DOCKER_USER}}/docker-gen
+      

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -97,7 +97,7 @@ func initFlags() {
 	flag.BoolVar(&notifyOutput, "notify-output", false, "log the output(stdout/stderr) of notify command")
 	flag.StringVar(&notifyCmd, "notify", "", "run command after template is regenerated (e.g `restart xyz`)")
 	flag.StringVar(&notifyContainerID, "notify-sighup", "",
-		"send HUP signal to container.  Equivalent to docker kill -s HUP `container-ID`")
+		"send HUP signal to container. You can either pass a container name/id or a filter key=value to send to multiple containers. Equivalent to docker kill -s HUP `container-ID`")
 	flag.StringVar(&notifyContainerID, "notify-container", "",
 		"container to send a signal to")
 	flag.IntVar(&notifyContainerSignal, "notify-signal", int(docker.SIGHUP),


### PR DESCRIPTION
This implementation will allow for the use of a filter to live query the containers before sending the sigup, and is fully backwards compatible with the previous implementation.

Resolves https://github.com/nginx-proxy/docker-gen/issues/77

New version of this pull request: https://github.com/nginx-proxy/docker-gen/pull/311