### PR TITLE
build: go 1.19 -> 1.20

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -15,9 +15,9 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Build release assets
         run: make release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Install dependencies
         run: make get-deps

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nginx-proxy/docker-gen
 
-go 1.19
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
This PR bump to Go version of the project to 1.20 and update `actions/setup-go` action to v4.