### PR TITLE
ci: add GitHub Actions to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
     commit-message:
       prefix: "build"
 
-
   # Maintain dependencies for Docker
   - package-ecosystem: "docker"
     directory: "/"
@@ -16,3 +15,11 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "build"
+
+  # Maintain GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
This PR: add GitHub Actions ecosystem to Dependabot.