### PR TITLE
docker: Add proper entrypoint

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -28,4 +28,5 @@ COPY --from=go-builder /build/docker-gen /usr/local/bin/docker-gen
 # Copy the license
 COPY LICENSE /usr/local/share/doc/docker-gen/
 
-ENTRYPOINT ["/usr/local/bin/docker-gen"]
+COPY "./container-entrypoint.sh" "/app/container-entrypoint.sh"
+ENTRYPOINT [ "/app/container-entrypoint.sh" ]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -32,4 +32,5 @@ COPY --from=go-builder /build/docker-gen /usr/local/bin/docker-gen
 # Copy the license
 COPY LICENSE /usr/local/share/doc/docker-gen/
 
-ENTRYPOINT ["/usr/local/bin/docker-gen"]
+COPY "./container-entrypoint.sh" "/app/container-entrypoint.sh"
+ENTRYPOINT [ "/app/container-entrypoint.sh" ]

--- a/app/container-entrypoint.sh
+++ b/app/container-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eu
+
+bin='docker-gen'
+
+# run command if it is not starting with a "-" and is an executable in PATH
+if [ "${#}" -le 0 ] || \
+   [ "${1#-}" != "${1}" ] || \
+   [ -d "${1}" ] || \
+   ! command -v "${1}" > '/dev/null' 2>&1; then
+	entrypoint='true'
+fi
+
+exec ${entrypoint:+${bin:?}} "${@}"
+
+exit 0


### PR DESCRIPTION
As per docker guidelines [0] a container should always really have a consistent entrypoint, without having to override it or do special tricks.

The behavior should be _identical_ as before, but will no longer trigger errors because docker-gen doesn't understand certain parameters (/bin/sh for example being common). Further more, allows a proper entrypoint for a CI to work easily with the container as well. Allowing for scenario's such as `apk add git && docker-gen renew` in a docker-gen image for example.

E.g. `docker run docker-gen --help` works, as does `docker run docker-gen /bin/sh` or `docker run docker-gen ls`.

[0]: https://github.com/docker-library/official-images#consistency