### PR TITLE
build: disable cgo on Debian image

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -12,7 +12,7 @@ COPY . .
 RUN go mod download
 
 # Build the docker-gen executable
-RUN GOOS=linux go build -ldflags "-X main.buildVersion=${DOCKER_GEN_VERSION}" -o docker-gen ./cmd/docker-gen
+RUN GOOS=linux CGO_ENABLED=0 go build -ldflags "-X main.buildVersion=${DOCKER_GEN_VERSION}" -o docker-gen ./cmd/docker-gen
 
 FROM debian:12.0-slim
 


### PR DESCRIPTION
This is a fix for https://github.com/nginx-proxy/nginx-proxy/issues/2268