### PR TITLE
Add support to pull data from multiple docker endpoints (e.g. swarm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Options:
       config files with template directives. Config files will be merged if this option is specified multiple times. (default [])
   -endpoint string
       docker api endpoint (tcp|unix://..). Default unix:///var/run/docker.sock
+  -swarm-node value
+      docker api endpoints from which to listen for events. Default equals to value of `endpoint` argument
   -interval int
       notify command interval (secs)
   -keep-blank-lines

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -34,6 +34,7 @@ var (
 	interval              int
 	keepBlankLines        bool
 	endpoint              string
+	swarmNodes            stringslice
 	tlsCert               string
 	tlsKey                string
 	tlsCaCert             string
@@ -106,6 +107,7 @@ func initFlags() {
 	flag.IntVar(&interval, "interval", 0, "notify command interval (secs)")
 	flag.BoolVar(&keepBlankLines, "keep-blank-lines", false, "keep blank lines in the output file")
 	flag.StringVar(&endpoint, "endpoint", "", "docker api endpoint (tcp|unix://..). Default unix:///var/run/docker.sock")
+	flag.Var(&swarmNodes, "swarm-node", "swarm node api endpoint (tcp|unix://..).")
 	flag.StringVar(&tlsCert, "tlscert", filepath.Join(certPath, "cert.pem"), "path to TLS client certificate file")
 	flag.StringVar(&tlsKey, "tlskey", filepath.Join(certPath, "key.pem"), "path to TLS client key file")
 	flag.StringVar(&tlsCaCert, "tlscacert", filepath.Join(certPath, "ca.pem"), "path to TLS CA certificate file")
@@ -174,6 +176,7 @@ func main() {
 
 	generator, err := generator.NewGenerator(generator.GeneratorConfig{
 		Endpoint:   endpoint,
+		SwarmNodes: swarmNodes,
 		TLSKey:     tlsKey,
 		TLSCert:    tlsCert,
 		TLSCACert:  tlsCaCert,

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -16,8 +16,6 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 	dockertest "github.com/fsouza/go-dockerclient/testing"
 	"github.com/nginx-proxy/docker-gen/internal/config"
-	"github.com/nginx-proxy/docker-gen/internal/context"
-	"github.com/nginx-proxy/docker-gen/internal/dockerclient"
 )
 
 func TestGenerateFromEvents(t *testing.T) {
@@ -106,11 +104,6 @@ func TestGenerateFromEvents(t *testing.T) {
 	}))
 
 	serverURL := fmt.Sprintf("tcp://%s", strings.TrimRight(strings.TrimPrefix(server.URL(), "http://"), "/"))
-	client, err := dockerclient.NewDockerClient(serverURL, false, "", "", "")
-	if err != nil {
-		t.Errorf("Failed to create client: %s", err)
-	}
-	client.SkipServerVersionCheck = true
 
 	tmplFile, err := os.CreateTemp(os.TempDir(), "docker-gen-tmpl")
 	if err != nil {
@@ -140,16 +133,10 @@ func TestGenerateFromEvents(t *testing.T) {
 		}
 	}()
 
-	apiVersion, err := client.Version()
-	if err != nil {
-		t.Errorf("Failed to retrieve docker server version info: %v\n", err)
-	}
-	context.SetDockerEnv(apiVersion) // prevents a panic
-
-	generator := &generator{
-		Client:   client,
-		Endpoint: serverURL,
-		Configs: config.ConfigFile{
+	generator, err := NewGenerator(GeneratorConfig{
+		Endpoint:  serverURL,
+		TLSVerify: false,
+		ConfigFile: config.ConfigFile{
 			Config: []config.Config{
 				{
 					Template: tmplFile.Name(),
@@ -176,8 +163,12 @@ func TestGenerateFromEvents(t *testing.T) {
 				},
 			},
 		},
-		retry: false,
+	})
+	if err != nil {
+		t.Errorf("Error creating generator: %v\n", err)
 	}
+
+	generator.retry = false
 
 	generator.generateFromEvents()
 	generator.wg.Wait()


### PR DESCRIPTION
This PR adds support to request container data from multiple docker endpoints. For example in swarm you now can get containers information from all nodes at once.

Main idea is that `endpoint` parameter refers to local docker node for which docker-gen generates configs. And the `swarm-node` parameters define additional docker nodes from which docker-gen pulls containers information.

Back compatability preserved. If no `swarm-node` stated then docker-gen collects information only from local docker endpoint defined by `endpoint` parameter.

In case when stated at least one `swarm-node` parameter docker-gen will collect containers information from swarm-node list. And use `endpoint` only for "controlling" purpose (e.g. to notify containers).

Root use-case for this PR is to make possible for projects like [nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) to have full information across all swarm cluster.