### PR TITLE
feat: add `Internal` property to `Network` struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ type Network struct {
     MacAddress          string
     GlobalIPv6PrefixLen int
     IPPrefixLen         int
+    Internal            bool
 }
 
 type DockerImage struct {

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -71,6 +71,7 @@ type Network struct {
 	MacAddress          string
 	GlobalIPv6PrefixLen int
 	IPPrefixLen         int
+	Internal            bool
 }
 
 type Volume struct {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -373,6 +373,15 @@ func (g *generator) getContainers() ([]*context.RuntimeContainer, error) {
 		return nil, err
 	}
 
+	apiNetworks, err := g.Client.ListNetworks()
+	if err != nil {
+		return nil, err
+	}
+	networks := make(map[string]docker.Network)
+	for _, apiNetwork := range apiNetworks {
+		networks[apiNetwork.Name] = apiNetwork
+	}
+
 	containers := []*context.RuntimeContainer{}
 	for _, apiContainer := range apiContainers {
 		opts := docker.InspectContainerOptions{ID: apiContainer.ID}
@@ -433,6 +442,7 @@ func (g *generator) getContainers() ([]*context.RuntimeContainer, error) {
 				MacAddress:          v.MacAddress,
 				GlobalIPv6PrefixLen: v.GlobalIPv6PrefixLen,
 				IPPrefixLen:         v.IPPrefixLen,
+				Internal:            networks[k].Internal,
 			}
 
 			runtimeContainer.Networks = append(runtimeContainer.Networks,


### PR DESCRIPTION
The purpose of this pull request is to add the `Internal` property to the `Network` structure so that it could be used to fix https://github.com/nginx-proxy/nginx-proxy/issues/2310.

I've tested that this change makes the fix for the nginx-proxy related issue easy:
```
diff --git a/nginx.tmpl b/nginx.tmpl
index fb0766b..afe5c96 100644
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -75,7 +75,7 @@
                 {{- continue }}
             {{- end }}
             {{- range sortObjectsByKeysAsc $.globals.CurrentContainer.Networks "Name" }}
-                {{- if and . .Gateway }}
+                {{- if and . .Gateway (not .Internal) }}
     #         container is in host network mode, using {{ .Name }} gateway IP
                     {{- $ip = .Gateway }}
                     {{- break }}
```

I have no knowledge in Go programming and it took me quite some time to come up with this proposal. Please bear with me :)