### PR TITLE
feat: sortObjectsByKeys with types other than string

### DIFF
--- a/internal/template/sort_test.go
+++ b/internal/template/sort_test.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"testing"
+	"time"
 
 	"github.com/nginx-proxy/docker-gen/internal/context"
 	"github.com/stretchr/testify/assert"
@@ -19,28 +20,61 @@ func TestSortStringsDesc(t *testing.T) {
 	assert.Equal(t, expected, sortStringsDesc(strings))
 }
 
+func TestGetFieldAsString(t *testing.T) {
+	testStruct := struct {
+		String string
+		BoolT  bool
+		BoolF  bool
+		Int    int
+		Int32  int32
+		Int64  int64
+		Time   time.Time
+	}{
+		String: "foo",
+		BoolT:  true,
+		BoolF:  false,
+		Int:    42,
+		Int32:  43,
+		Int64:  44,
+		Time:   time.Date(2023, 12, 19, 0, 0, 0, 0, time.UTC),
+	}
+
+	assert.Equal(t, "foo", getFieldAsString(testStruct, "String"))
+	assert.Equal(t, "true", getFieldAsString(testStruct, "BoolT"))
+	assert.Equal(t, "false", getFieldAsString(testStruct, "BoolF"))
+	assert.Equal(t, "42", getFieldAsString(testStruct, "Int"))
+	assert.Equal(t, "43", getFieldAsString(testStruct, "Int32"))
+	assert.Equal(t, "44", getFieldAsString(testStruct, "Int64"))
+	assert.Equal(t, "2023-12-19 00:00:00 +0000 UTC", getFieldAsString(testStruct, "Time"))
+	assert.Equal(t, "", getFieldAsString(testStruct, "InvalidField"))
+}
+
 func TestSortObjectsByKeys(t *testing.T) {
 	o0 := &context.RuntimeContainer{
+		Created: time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC),
 		Env: map[string]string{
 			"VIRTUAL_HOST": "bar.localhost",
 		},
 		ID: "9",
 	}
 	o1 := &context.RuntimeContainer{
+		Created: time.Date(2021, 1, 2, 0, 0, 10, 0, time.UTC),
 		Env: map[string]string{
 			"VIRTUAL_HOST": "foo.localhost",
 		},
 		ID: "1",
 	}
 	o2 := &context.RuntimeContainer{
+		Created: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
 		Env: map[string]string{
 			"VIRTUAL_HOST": "baz.localhost",
 		},
 		ID: "3",
 	}
 	o3 := &context.RuntimeContainer{
-		Env: map[string]string{},
-		ID:  "8",
+		Created: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		Env:     map[string]string{},
+		ID:      "8",
 	}
 	containers := []*context.RuntimeContainer{o0, o1, o2, o3}
 
@@ -54,6 +88,8 @@ func TestSortObjectsByKeys(t *testing.T) {
 		{"Asc complex", sortObjectsByKeysAsc, "Env.VIRTUAL_HOST", []interface{}{o3, o0, o2, o1}},
 		{"Desc simple", sortObjectsByKeysDesc, "ID", []interface{}{o0, o3, o2, o1}},
 		{"Desc complex", sortObjectsByKeysDesc, "Env.VIRTUAL_HOST", []interface{}{o1, o2, o0, o3}},
+		{"Asc time", sortObjectsByKeysAsc, "Created", []interface{}{o3, o0, o2, o1}},
+		{"Desc time", sortObjectsByKeysDesc, "Created", []interface{}{o1, o2, o0, o3}},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			got, err := tc.fn(containers, tc.key)


### PR DESCRIPTION
The PR add support for the following types to `sortObjectsByKeysAsc` and `sortObjectsByKeysDesc` template functions:
- `int`
- `int32`
- `int64`
- `bool`
- `time.Time`

This should help fix https://github.com/nginx-proxy/acme-companion/issues/1049