### PR TITLE
fix: windows build

### DIFF
--- a/internal/template/chown_unix.go
+++ b/internal/template/chown_unix.go
@@ -1,0 +1,18 @@
+//go:build linux || darwin
+
+package template
+
+import (
+	"io/fs"
+	"log"
+	"os"
+	"syscall"
+)
+
+func chown(dest *os.File, fi fs.FileInfo) {
+	if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
+		if err := dest.Chown(int(stat.Uid), int(stat.Gid)); err != nil {
+			log.Fatalf("Unable to chown temp file: %s\n", err)
+		}
+	}
+}

--- a/internal/template/chown_windows.go
+++ b/internal/template/chown_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package template
+
+import (
+	"io/fs"
+	"os"
+)
+
+func chown(dest *os.File, fi fs.FileInfo) {
+	// do nothing
+}

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -13,7 +13,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"syscall"
 	"text/template"
 	"unicode"
 
@@ -195,12 +194,13 @@ func GenerateFile(config config.Config, containers context.Context) bool {
 					fi, _ = os.Stat(config.Dest)
 				}
 			}
+
 			if err := dest.Chmod(fi.Mode()); err != nil {
 				log.Fatalf("Unable to chmod temp file: %s\n", err)
 			}
-			if err := dest.Chown(int(fi.Sys().(*syscall.Stat_t).Uid), int(fi.Sys().(*syscall.Stat_t).Gid)); err != nil {
-				log.Fatalf("Unable to chown temp file: %s\n", err)
-			}
+
+			chown(dest, fi)
+
 			oldContents, err = os.ReadFile(config.Dest)
 			if err != nil {
 				log.Fatalf("Unable to compare current file contents: %s: %s\n", config.Dest, err)


### PR DESCRIPTION
This PR fixes windows builds merged in #307.

Windows doe not have `syscall.Stat_t` and [os's `Chown()` does not work for this OS](https://pkg.go.dev/os#File.Chown).