### PR TITLE
build: revert "bump golang from 1.20.12 to 1.21.5"

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.20"
 
       - name: Build release assets
         run: make release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.20"
 
       - name: Install dependencies
         run: make get-deps

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,7 @@
 ARG DOCKER_GEN_VERSION=main
 
 # Build docker-gen from scratch
-FROM golang:1.21.5-alpine as go-builder
+FROM golang:1.20.12-alpine as go-builder
 
 ARG DOCKER_GEN_VERSION
 WORKDIR /build

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,7 +1,7 @@
 ARG DOCKER_GEN_VERSION=main
 
 # Build docker-gen from scratch
-FROM golang:1.21.5 as go-builder
+FROM golang:1.20.12 as go-builder
 
 ARG DOCKER_GEN_VERSION
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nginx-proxy/docker-gen
 
-go 1.21
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.3.2


### PR DESCRIPTION
This reverts commit 2bd8114a107a7fe09cc32edd50d13873ce203b24.

See https://github.com/docker-library/golang/issues/502 for the revert to go 1.20 reason.