### PR TITLE
build: bump golang from 1.20.12 to 1.21.5

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Build release assets
         run: make release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Install dependencies
         run: make get-deps

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,7 @@
 ARG DOCKER_GEN_VERSION=main
 
 # Build docker-gen from scratch
-FROM --platform=$BUILDPLATFORM golang:1.20.12-alpine as go-builder
+FROM --platform=$BUILDPLATFORM golang:1.21.5-alpine as go-builder
 
 ENV CGO_ENABLED=0
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,7 +1,7 @@
 ARG DOCKER_GEN_VERSION=main
 
 # Build docker-gen from scratch
-FROM --platform=$BUILDPLATFORM golang:1.20.12 as go-builder
+FROM --platform=$BUILDPLATFORM golang:1.21.5 as go-builder
 
 ENV CGO_ENABLED=0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nginx-proxy/docker-gen
 
-go 1.20
+go 1.21
 
 require (
 	github.com/BurntSushi/toml v1.3.2


### PR DESCRIPTION
Now that we're using cross compiling instead of emulation (#586), we should be able to update go to 1.21 and still build for every arch we want (see #585).