### PR TITLE
fix: don't include stopped containers by default

### DIFF
--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -165,7 +165,7 @@ func main() {
 			Config: []config.Config{cfg}}
 	}
 
-	all := true
+	all := false
 	for _, config := range configs.Config {
 		if config.IncludeStopped {
 			all = true


### PR DESCRIPTION
~~As remarked by @karlyan17 in #314, the configuration option `-include-stopped` has no effect because the inclusion of stopped containers was hard set to `true` internally.~~

Edit: the issue is actually a bit different.

The inclusion of stopped containers happen in two steps:
1. first docker-gen either query the Docker API endpoint for all containers or only running containers
2. this containers list is either filtered to keep only the running ones (default) or not filtered at all (`-include-stopped`)

The second step works correctly and probably always have.

The first step is the one having an issue : docker-gen **always get all the containers** from the Docker API endpoint even when `-include-stopped` is not used. This does not impact `-include-stopped`, but it means docker-gen always fetch more data than necessary from the Docker API endpoint when not using this feature.

Fix #314 