### PR TITLE
feat: filter containers to notify 

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,14 @@ Options:
       log the output(stdout/stderr) of notify command
   -notify-container container-ID
       container to send a signal to
+  -notify-filter key=value
+      container filter for notification (e.g -notify-filter name=foo).
+      You can have multiple of these.
+      https://docs.docker.com/engine/reference/commandline/ps/#filter
   -notify-signal signal
-      signal to send to the -notify-container. -1 to call docker restart. Defaults to 1 aka. HUP.
-      All available signals available on the [dockerclient](https://github.com/fsouza/go-dockerclient/blob/01804dec8a84d0a77e63611f2b62d33e9bb2b64a/signal.go)
+      signal to send to the -notify-container and -notify-filter. -1 to call docker restart. Defaults to 1 aka. HUP.
+      All available signals available on the dockerclient
+      https://github.com/fsouza/go-dockerclient/blob/01804dec8a84d0a77e63611f2b62d33e9bb2b64a/signal.go
   -notify-sighup container-ID
       send HUP signal to container.  Equivalent to 'docker kill -s HUP container-ID', or `-notify-container container-ID -notify-signal 1`
   -only-exposed

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 type stringslice []string
-type notifyfilter map[string][]string
+type mapstringslice map[string][]string
 
 var (
 	buildVersion          string
@@ -28,7 +28,7 @@ var (
 	notifyOutput          bool
 	notifyContainerID     string
 	notifyContainerSignal int
-	notifyContainerFilter notifyfilter = make(notifyfilter)
+	notifyContainerFilter mapstringslice = make(mapstringslice)
 	onlyExposed           bool
 	onlyPublished         bool
 	includeStopped        bool
@@ -53,13 +53,15 @@ func (strings *stringslice) Set(value string) error {
 	return nil
 }
 
-func (filter *notifyfilter) String() string {
+func (filter *mapstringslice) String() string {
 	return "[string][]string"
 }
 
-func (filter *notifyfilter) Set(value string) error {
-	name, value, _ := strings.Cut(value, "=")
-	(*filter)[name] = append((*filter)[name], value)
+func (filter *mapstringslice) Set(value string) error {
+	name, value, found := strings.Cut(value, "=")
+	if found {
+		(*filter)[name] = append((*filter)[name], value)
+	}
 	return nil
 }
 

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -115,10 +115,10 @@ func initFlags() {
 		"send HUP signal to container.  Equivalent to docker kill -s HUP `container-ID`")
 	flag.StringVar(&notifyContainerID, "notify-container", "",
 		"container to send a signal to")
-	flag.IntVar(&notifyContainerSignal, "notify-signal", int(docker.SIGHUP),
-		"signal to send to the notify-container. Defaults to SIGHUP")
 	flag.Var(&notifyContainerFilter, "notify-filter",
 		"container filter for notification (e.g -notify-filter name=foo). You can have multiple of these. https://docs.docker.com/engine/reference/commandline/ps/#filter")
+	flag.IntVar(&notifyContainerSignal, "notify-signal", int(docker.SIGHUP),
+		"signal to send to the notify-container and notify-filter. Defaults to SIGHUP")
 	flag.Var(&configFiles, "config", "config files with template directives. Config files will be merged if this option is specified multiple times.")
 	flag.IntVar(&interval, "interval", 0, "notify command interval (secs)")
 	flag.BoolVar(&keepBlankLines, "keep-blank-lines", false, "keep blank lines in the output file")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,18 +7,20 @@ import (
 )
 
 type Config struct {
-	Template         string
-	Dest             string
-	Watch            bool
-	Wait             *Wait
-	NotifyCmd        string
-	NotifyOutput     bool
-	NotifyContainers map[string]int
-	OnlyExposed      bool
-	OnlyPublished    bool
-	IncludeStopped   bool
-	Interval         int
-	KeepBlankLines   bool
+	Template               string
+	Dest                   string
+	Watch                  bool
+	Wait                   *Wait
+	NotifyCmd              string
+	NotifyOutput           bool
+	NotifyContainers       map[string]int
+	NotifyContainersFilter map[string][]string
+	NotifyContainersSignal int
+	OnlyExposed            bool
+	OnlyPublished          bool
+	IncludeStopped         bool
+	Interval               int
+	KeepBlankLines         bool
 }
 
 type ConfigFile struct {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -373,6 +373,7 @@ func (g *generator) sendSignalToContainers(config config.Config) {
 		return
 	}
 	for _, container := range containers {
+		log.Printf("Sending container '%s' signal '%v'", container.ID, config.NotifyContainersSignal)
 		if config.NotifyContainersSignal == -1 {
 			if err := g.Client.RestartContainer(container.ID, 10); err != nil {
 				log.Printf("Error sending restarting container: %s", err)


### PR DESCRIPTION
This is a rebase and slight refactor of #549 (without behaviour change) + documentation.

Original description from @tarasov65536:

> This PR gives ability to specify set of filters to containers query when new generated file arrived.
> 
> It is kinda similar to [#311](https://github.com/nginx-proxy/docker-gen/pull/311) but with better implementation from architectural point of view.
> 
> It introduces new command line argument `-notify-filter` that adds filter in list of filters to query containers that should be notified when generated file changed. Argument format as in [docker api](https://docs.docker.com/engine/reference/commandline/ps/#filter)
> 
> For example:
> ```sh
> docker-gen -notify-filter name=foo -notify-filter label=bar=baz ...
> ```
> adds two filters to containers query.
> 
> Signal code still defined by argument `-notify-signal`.

As pointed out in the original PR, docker-gen is not structured to make this realistically unit testable, but it work as advertised and does not seem to introduce regressions.

Resolves #77