### PR TITLE
feat: allow multiple -notify-sighup / -notify-container

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,12 @@ Options:
       You can pass this option multiple times to notify multiple containers.
   -notify-filter key=value
       container filter for notification (e.g -notify-filter name=foo).
-      You can have multiple of these.
+      You can pass this option multiple times to combine filters with AND.
       https://docs.docker.com/engine/reference/commandline/ps/#filter
   -notify-signal signal
       signal to send to the -notify-container and -notify-filter. -1 to call docker restart. Defaults to 1 aka. HUP.
       All available signals available on the dockerclient
-      https://github.com/fsouza/go-dockerclient/blob/01804dec8a84d0a77e63611f2b62d33e9bb2b64a/signal.go
+      https://github.com/fsouza/go-dockerclient/blob/main/signal.go
   -only-exposed
       only include containers with exposed ports
   -only-published
@@ -121,11 +121,11 @@ Options:
   -include-stopped
       include stopped containers
   -tlscacert string
-      path to TLS CA certificate file (default "/Users/jason/.docker/machine/machines/default/ca.pem")
+      path to TLS CA certificate file (default "~/.docker/machine/machines/default/ca.pem")
   -tlscert string
-      path to TLS client certificate file (default "/Users/jason/.docker/machine/machines/default/cert.pem")
+      path to TLS client certificate file (default "~/.docker/machine/machines/default/cert.pem")
   -tlskey string
-      path to TLS client key file (default "/Users/jason/.docker/machine/machines/default/key.pem")
+      path to TLS client key file (default "~/.docker/machine/machines/default/key.pem")
   -tlsverify
       verify docker daemon's TLS certicate (default true)
   -version

--- a/README.md
+++ b/README.md
@@ -99,8 +99,13 @@ Options:
       run command after template is regenerated (e.g restart xyz)
   -notify-output
       log the output(stdout/stderr) of notify command
+  -notify-sighup container-ID
+      send HUP signal to container.
+      Equivalent to 'docker kill -s HUP container-ID', or `-notify-container container-ID -notify-signal 1`.
+      You can pass this option multiple times to send HUP to multiple containers.
   -notify-container container-ID
-      container to send a signal to
+      send -notify-signal signal (defaults to 1 / HUP) to container.
+      You can pass this option multiple times to notify multiple containers.
   -notify-filter key=value
       container filter for notification (e.g -notify-filter name=foo).
       You can have multiple of these.
@@ -109,8 +114,6 @@ Options:
       signal to send to the -notify-container and -notify-filter. -1 to call docker restart. Defaults to 1 aka. HUP.
       All available signals available on the dockerclient
       https://github.com/fsouza/go-dockerclient/blob/01804dec8a84d0a77e63611f2b62d33e9bb2b64a/signal.go
-  -notify-sighup container-ID
-      send HUP signal to container.  Equivalent to 'docker kill -s HUP container-ID', or `-notify-container container-ID -notify-signal 1`
   -only-exposed
       only include containers with exposed ports
   -only-published

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -49,7 +50,6 @@ func (strings *stringslice) String() string {
 }
 
 func (strings *stringslice) Set(value string) error {
-	// TODO: Throw an error for duplicate `dest`
 	*strings = append(*strings, value)
 	return nil
 }
@@ -150,6 +150,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	slices.Sort(configFiles)
+	configFiles = slices.Compact(configFiles)
+
 	if len(configFiles) > 0 {
 		for _, configFile := range configFiles {
 			err := loadConfig(configFile)
@@ -187,7 +190,8 @@ func main() {
 			cfg.NotifyContainersSignal = notifyContainerSignal
 		}
 		configs = config.ConfigFile{
-			Config: []config.Config{cfg}}
+			Config: []config.Config{cfg},
+		}
 	}
 
 	all := false

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -26,8 +26,8 @@ var (
 	wait                  string
 	notifyCmd             string
 	notifyOutput          bool
-	sighupContainerID     string
-	notifyContainerID     string
+	sighupContainerID     stringslice
+	notifyContainerID     stringslice
 	notifyContainerSignal int
 	notifyContainerFilter mapstringslice = make(mapstringslice)
 	onlyExposed           bool
@@ -112,10 +112,10 @@ func initFlags() {
 	flag.BoolVar(&includeStopped, "include-stopped", false, "include stopped containers")
 	flag.BoolVar(&notifyOutput, "notify-output", false, "log the output(stdout/stderr) of notify command")
 	flag.StringVar(&notifyCmd, "notify", "", "run command after template is regenerated (e.g `restart xyz`)")
-	flag.StringVar(&sighupContainerID, "notify-sighup", "",
-		"send HUP signal to container.  Equivalent to docker kill -s HUP `container-ID`")
-	flag.StringVar(&notifyContainerID, "notify-container", "",
-		"container to send a signal to")
+	flag.Var(&sighupContainerID, "notify-sighup",
+		"send HUP signal to container. Equivalent to docker kill -s HUP `container-ID`. You can pass this option multiple times to send HUP to multiple containers.")
+	flag.Var(&notifyContainerID, "notify-container",
+		"send -notify-signal signal (defaults to 1 / HUP) to container. You can pass this option multiple times to notify multiple containers.")
 	flag.Var(&notifyContainerFilter, "notify-filter",
 		"container filter for notification (e.g -notify-filter name=foo). You can have multiple of these. https://docs.docker.com/engine/reference/commandline/ps/#filter")
 	flag.IntVar(&notifyContainerSignal, "notify-signal", int(docker.SIGHUP),
@@ -176,11 +176,11 @@ func main() {
 			Interval:         interval,
 			KeepBlankLines:   keepBlankLines,
 		}
-		if sighupContainerID != "" {
-			cfg.NotifyContainers[sighupContainerID] = int(syscall.SIGHUP)
+		for _, id := range sighupContainerID {
+			cfg.NotifyContainers[id] = int(syscall.SIGHUP)
 		}
-		if notifyContainerID != "" {
-			cfg.NotifyContainers[notifyContainerID] = notifyContainerSignal
+		for _, id := range notifyContainerID {
+			cfg.NotifyContainers[id] = notifyContainerSignal
 		}
 		if len(notifyContainerFilter) > 0 {
 			cfg.NotifyContainersFilter = notifyContainerFilter

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -117,7 +117,7 @@ func initFlags() {
 	flag.Var(&notifyContainerID, "notify-container",
 		"send -notify-signal signal (defaults to 1 / HUP) to container. You can pass this option multiple times to notify multiple containers.")
 	flag.Var(&notifyContainerFilter, "notify-filter",
-		"container filter for notification (e.g -notify-filter name=foo). You can have multiple of these. https://docs.docker.com/engine/reference/commandline/ps/#filter")
+		"container filter for notification (e.g -notify-filter name=foo). You can pass this option multiple times to combine filters with AND. https://docs.docker.com/engine/reference/commandline/ps/#filter")
 	flag.IntVar(&notifyContainerSignal, "notify-signal", int(docker.SIGHUP),
 		"signal to send to the notify-container and notify-filter. Defaults to SIGHUP")
 	flag.Var(&configFiles, "config", "config files with template directives. Config files will be merged if this option is specified multiple times.")


### PR DESCRIPTION
The `-notify-sighup` and `-notify-container` option were obviously planned to allow them to be passed multiple times, since they're internally stored as a `map` of container ID (`string`) to signal (`int`). This PR make it possible to use both of those options multiple times, like this:

```console
docker-gen \
    -notify-sighup container1 \
    -notify-sighup container2 \
    -notify-container container3 \
    -notify-container container4 \
    -notify-signal 2 \
    ./some/template.tmpl ./result.ext
```

This would send HUP (1) to container1 and container2 and INT (2) to container3 and container4.

For notifying large amount of containers, [the recently added `-notify-filter`](https://github.com/nginx-proxy/docker-gen/pull/619) is preferable.

There was also a TODO for preventing duplicate paths being passed to `-config` that this PR fixes.