### PR TITLE
refactor: cleanup template functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 - [Functions from Go](https://pkg.go.dev/text/template#hdr-Functions)
 - [Functions from Sprig v3](https://masterminds.github.io/sprig/), except for those that have the same name as one of the following functions.
 - _`closest $array $value`_: Returns the longest matching substring in `$array` that matches `$value`
+- _`coalesce ...`_: Returns the first non-nil argument.
 - _`comment $delimiter $string`_: Returns `$string` with each line prefixed by `$delimiter` (helpful for debugging combined with Sprig `toPrettyJson`: `{{ toPrettyJson $ | comment "#" }}`).
 - _`contains $map $key`_: Returns `true` if `$map` contains `$key`. Takes maps from `string` to any type.
 - _`dir $path`_: Returns an array of filenames in the specified `$path`.
@@ -417,6 +418,7 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 
 Sprig functions that have the same name as docker-gen function (but different behaviour) are made available with the `sprig` prefix:
 
+- _`sprigCoalesce ...`_: Alias for Sprig's [`coalesce`](https://masterminds.github.io/sprig/defaults.html).
 - _`sprigContains $string $string`_: Alias for Sprig's [`contains`](https://masterminds.github.io/sprig/strings.html).
 - _`sprigDir $path`_: Alias for Sprig's [`dir`](https://masterminds.github.io/sprig/paths.html).
 - _`sprigReplace $old $new $string`_: Alias for Sprig's [`replace`](https://masterminds.github.io/sprig/strings.html).

--- a/README.md
+++ b/README.md
@@ -384,7 +384,6 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 - [Functions from Go](https://pkg.go.dev/text/template#hdr-Functions)
 - [Functions from Sprig v3](https://masterminds.github.io/sprig/), except for those that have the same name as one of the following functions.
 - _`closest $array $value`_: Returns the longest matching substring in `$array` that matches `$value`
-- _`coalesce ...`_: Returns the first non-nil argument.
 - _`comment $delimiter $string`_: Returns `$string` with each line prefixed by `$delimiter` (helpful for debugging combined with Sprig `toPrettyJson`: `{{ toPrettyJson $ | comment "#" }}`).
 - _`contains $map $key`_: Returns `true` if `$map` contains `$key`. Takes maps from `string` to any type.
 - _`dir $path`_: Returns an array of filenames in the specified `$path`.
@@ -398,23 +397,13 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 - _`groupByLabelWithDefault $containers $label $defaultValue`_: Returns the same as `groupBy` but grouping by the given label's value. Containers that do not have the `$label` set are included in the map under the `$defaultValue` key.
 - _`include $file`_: Returns content of `$file`, and empty string if file reading error.
 - _`intersect $slice1 $slice2`_: Returns the strings that exist in both string slices.
-- _`json $value`_: Returns the JSON representation of `$value` as a `string`.
 - _`fromYaml $string` / `mustFromYaml $string`_: Similar to [Sprig's `fromJson` / `mustFromJson`](https://github.com/Masterminds/sprig/blob/master/docs/defaults.md#fromjson-mustfromjson), but for YAML.
 - _`toYaml $dict` / `mustToYaml $dict`_: Similar to [Sprig's `toJson` / `mustToJson`](https://github.com/Masterminds/sprig/blob/master/docs/defaults.md#tojson-musttojson), but for YAML.
 - _`keys $map`_: Returns the keys from `$map`. If `$map` is `nil`, a `nil` is returned. If `$map` is not a `map`, an error will be thrown.
-- _`parseBool $string`_: parseBool returns the boolean value represented by the string. It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False. Any other value returns an error. Alias for [`strconv.ParseBool`](http://golang.org/pkg/strconv/#ParseBool)
-- _`replace $string $old $new $count`_: Replaces up to `$count` occurences of `$old` with `$new` in `$string`. Alias for [`strings.Replace`](http://golang.org/pkg/strings/#Replace)
-- _`sha1 $string`_: Returns the hexadecimal representation of the SHA1 hash of `$string`.
-- _`split $string $sep`_: Splits `$string` into a slice of substrings delimited by `$sep`. Alias for [`strings.Split`](http://golang.org/pkg/strings/#Split)
-- _`splitN $string $sep $count`_: Splits `$string` into a slice of substrings delimited by `$sep`, with number of substrings returned determined by `$count`. Alias for [`strings.SplitN`](https://golang.org/pkg/strings/#SplitN)
 - _`sortStringsAsc $strings`_: Returns a slice of strings `$strings` sorted in ascending order.
 - _`sortStringsDesc $strings`_: Returns a slice of strings `$strings` sorted in descending (reverse) order.
 - _`sortObjectsByKeysAsc $objects $fieldPath`_: Returns the array `$objects`, sorted in ascending order based on the values of a field path expression `$fieldPath`.
 - _`sortObjectsByKeysDesc $objects $fieldPath`_: Returns the array `$objects`, sorted in descending (reverse) order based on the values of a field path expression `$fieldPath`.
-- _`trimPrefix $prefix $string`_: If `$prefix` is a prefix of `$string`, return `$string` with `$prefix` trimmed from the beginning. Otherwise, return `$string` unchanged.
-- _`trimSuffix $suffix $string`_: If `$suffix` is a suffix of `$string`, return `$string` with `$suffix` trimmed from the end. Otherwise, return `$string` unchanged.
-- _`toLower $string`_: Replace capital letters in `$string` to lowercase.
-- _`toUpper $string`_: Replace lowercase letters in `$string` to uppercase.
 - _`when $condition $trueValue $falseValue`_: Returns the `$trueValue` when the `$condition` is `true` and the `$falseValue` otherwise
 - _`where $items $fieldPath $value`_: Filters an array or slice based on the values of a field path expression `$fieldPath`. A field path expression is a dot-delimited list of map keys or struct member names specifying the path from container to a nested value. Returns an array of items having that value.
 - _`whereNot $items $fieldPath $value`_: Filters an array or slice based on the values of a field path expression `$fieldPath`. A field path expression is a dot-delimited list of map keys or struct member names specifying the path from container to a nested value. Returns an array of items **not** having that value.
@@ -425,6 +414,21 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 - _`whereLabelExists $containers $label`_: Filters a slice of containers based on the existence of the label `$label`.
 - _`whereLabelDoesNotExist $containers $label`_: Filters a slice of containers based on the non-existence of the label `$label`.
 - _`whereLabelValueMatches $containers $label $pattern`_: Filters a slice of containers based on the existence of the label `$label` with values matching the regular expression `$pattern`.
+
+Some functions are aliases for Go's [`strings`](https://pkg.go.dev/strings) package functions:
+
+- _`parseBool $string`_: Alias for [`strconv.ParseBool`](http://golang.org/pkg/strconv/#ParseBool). Returns the boolean value represented by `$string`. It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False. Any other value returns an error.
+- _`replace $string $old $new $count`_: Alias for [`strings.Replace`](http://golang.org/pkg/strings/#Replace). Replaces up to `$count` occurences of `$old` with `$new` in `$string`.
+- _`split $string $sep`_: Alias for [`strings.Split`](http://golang.org/pkg/strings/#Split). Splits `$string` into a slice of substrings delimited by `$sep`.
+- _`splitN $string $sep $count`_: Alias for [`strings.SplitN`](https://golang.org/pkg/strings/#SplitN). Splits `$string` into a slice of substrings delimited by `$sep`, with number of substrings returned determined by `$count`.
+- _`toLower $string`_: Alias for [`strings.ToLower`](https://pkg.go.dev/strings#ToLower). Replace capital letters in `$string` to lowercase.
+- _`toUpper $string`_: Alias for [`strings.ToUpper`](https://pkg.go.dev/strings#ToUpper). Replace lowercase letters in `$string` to uppercase.
+
+Those have been aliased to Sprig functions with the same behaviour as the original docker-gen function:
+
+- _`json $value`_: Alias for Sprig's [`mustToJson`](https://masterminds.github.io/sprig/defaults.html)
+- _`parseJson $string`_: Alias for Sprig's [`mustFromJson`](https://masterminds.github.io/sprig/defaults.html).
+- _`sha1 $string`_: Alias for Sprig's [`sha1sum`](https://masterminds.github.io/sprig/crypto.html).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -415,6 +415,14 @@ For example, this is a JSON version of an emitted RuntimeContainer struct:
 - _`whereLabelDoesNotExist $containers $label`_: Filters a slice of containers based on the non-existence of the label `$label`.
 - _`whereLabelValueMatches $containers $label $pattern`_: Filters a slice of containers based on the existence of the label `$label` with values matching the regular expression `$pattern`.
 
+Sprig functions that have the same name as docker-gen function (but different behaviour) are made available with the `sprig` prefix:
+
+- _`sprigContains $string $string`_: Alias for Sprig's [`contains`](https://masterminds.github.io/sprig/strings.html).
+- _`sprigDir $path`_: Alias for Sprig's [`dir`](https://masterminds.github.io/sprig/paths.html).
+- _`sprigReplace $old $new $string`_: Alias for Sprig's [`replace`](https://masterminds.github.io/sprig/strings.html).
+- _`sprigSplit $sep $string`_: Alias for Sprig's [`split`](https://masterminds.github.io/sprig/string_slice.html).
+- _`sprigSplitn $sep $count $string"`_: Alias for Sprig's [`splitn`](https://masterminds.github.io/sprig/string_slice.html).
+
 Some functions are aliases for Go's [`strings`](https://pkg.go.dev/strings) package functions:
 
 - _`parseBool $string`_: Alias for [`strconv.ParseBool`](http://golang.org/pkg/strconv/#ParseBool). Returns the boolean value represented by `$string`. It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False. Any other value returns an error.

--- a/internal/template/functions.go
+++ b/internal/template/functions.go
@@ -7,11 +7,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
-
-	"github.com/Masterminds/sprig/v3"
 )
-
-var sprigFuncMap = sprig.TxtFuncMap()
 
 func keys(input interface{}) (interface{}, error) {
 	if input == nil {
@@ -81,18 +77,6 @@ func contains(input interface{}, key interface{}) bool {
 	return false
 }
 
-func hashSha1(input string) string {
-	return sprigFuncMap["sha1sum"].(func(string) string)(input)
-}
-
-func marshalJson(input interface{}) (string, error) {
-	return sprigFuncMap["mustToJson"].(func(interface{}) (string, error))(input)
-}
-
-func unmarshalJson(input string) (interface{}, error) {
-	return sprigFuncMap["mustFromJson"].(func(string) (interface{}, error))(input)
-}
-
 // arrayClosest find the longest matching substring in values
 // that matches input
 func arrayClosest(values []string, input string) string {
@@ -117,21 +101,6 @@ func dirList(path string) ([]string, error) {
 		names = append(names, f.Name())
 	}
 	return names, nil
-}
-
-// coalesce returns the first non nil argument
-func coalesce(input ...interface{}) interface{} {
-	return sprigFuncMap["coalesce"].(func(...interface{}) interface{})(input...)
-}
-
-// trimPrefix returns a string without the prefix, if present
-func trimPrefix(prefix, s string) string {
-	return sprigFuncMap["trimPrefix"].(func(string, string) string)(prefix, s)
-}
-
-// trimSuffix returns a string without the suffix, if present
-func trimSuffix(suffix, s string) string {
-	return sprigFuncMap["trimSuffix"].(func(string, string) string)(suffix, s)
 }
 
 // when returns the trueValue when the condition is true and the falseValue otherwise

--- a/internal/template/functions.go
+++ b/internal/template/functions.go
@@ -103,6 +103,16 @@ func dirList(path string) ([]string, error) {
 	return names, nil
 }
 
+// coalesce returns the first non nil argument
+func coalesce(input ...interface{}) interface{} {
+	for _, v := range input {
+		if v != nil {
+			return v
+		}
+	}
+	return nil
+}
+
 // when returns the trueValue when the condition is true and the falseValue otherwise
 func when(condition bool, trueValue, falseValue interface{}) interface{} {
 	if condition {

--- a/internal/template/functions_test.go
+++ b/internal/template/functions_test.go
@@ -236,3 +236,11 @@ func TestDirList(t *testing.T) {
 	filesList, _ = dirList("/wrong/path")
 	assert.Equal(t, []string{}, filesList)
 }
+
+func TestCoalesce(t *testing.T) {
+	v := coalesce(nil, "second", "third")
+	assert.Equal(t, "second", v, "Expected second value")
+
+	v = coalesce(nil, nil, nil)
+	assert.Nil(t, v, "Expected nil value")
+}

--- a/internal/template/functions_test.go
+++ b/internal/template/functions_test.go
@@ -1,14 +1,11 @@
 package template
 
 import (
-	"bytes"
-	"encoding/json"
 	"os"
 	"path"
 	"reflect"
 	"testing"
 
-	"github.com/nginx-proxy/docker-gen/internal/context"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -130,73 +127,6 @@ func TestSplitN(t *testing.T) {
 	tests.run(t)
 }
 
-func TestTrimPrefix(t *testing.T) {
-	const prefix = "tcp://"
-	const str = "tcp://127.0.0.1:2375"
-	const trimmed = "127.0.0.1:2375"
-	got := trimPrefix(prefix, str)
-	if got != trimmed {
-		t.Fatalf("expected trimPrefix(%s,%s) to be %s, got %s", prefix, str, trimmed, got)
-	}
-}
-
-func TestTrimSuffix(t *testing.T) {
-	const suffix = ".local"
-	const str = "myhost.local"
-	const trimmed = "myhost"
-	got := trimSuffix(suffix, str)
-	if got != trimmed {
-		t.Fatalf("expected trimSuffix(%s,%s) to be %s, got %s", suffix, str, trimmed, got)
-	}
-}
-
-func TestSha1(t *testing.T) {
-	sum := hashSha1("/path")
-	if sum != "4f26609ad3f5185faaa9edf1e93aa131e2131352" {
-		t.Fatal("Incorrect SHA1 sum")
-	}
-}
-
-func TestJson(t *testing.T) {
-	containers := []*context.RuntimeContainer{
-		{
-			Env: map[string]string{
-				"VIRTUAL_HOST": "demo1.localhost",
-			},
-			ID: "1",
-		},
-		{
-			Env: map[string]string{
-				"VIRTUAL_HOST": "demo1.localhost,demo3.localhost",
-			},
-			ID: "2",
-		},
-		{
-			Env: map[string]string{
-				"VIRTUAL_HOST": "demo2.localhost",
-			},
-			ID: "3",
-		},
-	}
-	output, err := marshalJson(containers)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	buf := bytes.NewBufferString(output)
-	dec := json.NewDecoder(buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var decoded []*context.RuntimeContainer
-	if err := dec.Decode(&decoded); err != nil {
-		t.Fatal(err)
-	}
-	if len(decoded) != len(containers) {
-		t.Fatalf("Incorrect unmarshaled container count. Expected %d, got %d.", len(containers), len(decoded))
-	}
-}
-
 func TestParseJson(t *testing.T) {
 	tests := templateTestList{
 		{`{{parseJson .}}`, `null`, `<no value>`},
@@ -305,12 +235,4 @@ func TestDirList(t *testing.T) {
 
 	filesList, _ = dirList("/wrong/path")
 	assert.Equal(t, []string{}, filesList)
-}
-
-func TestCoalesce(t *testing.T) {
-	v := coalesce(nil, "second", "third")
-	assert.Equal(t, "second", v, "Expected second value")
-
-	v = coalesce(nil, nil, nil)
-	assert.Nil(t, v, "Expected nil value")
 }

--- a/internal/template/functions_test.go
+++ b/internal/template/functions_test.go
@@ -150,18 +150,6 @@ func TestTrimSuffix(t *testing.T) {
 	}
 }
 
-func TestToLower(t *testing.T) {
-	const str = ".RaNd0m StrinG_"
-	const lowered = ".rand0m string_"
-	assert.Equal(t, lowered, toLower(str), "Unexpected value from toLower()")
-}
-
-func TestToUpper(t *testing.T) {
-	const str = ".RaNd0m StrinG_"
-	const uppered = ".RAND0M STRING_"
-	assert.Equal(t, uppered, toUpper(str), "Unexpected value from toUpper()")
-}
-
 func TestSha1(t *testing.T) {
 	sum := hashSha1("/path")
 	if sum != "4f26609ad3f5185faaa9edf1e93aa131e2131352" {

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -59,7 +59,6 @@ func newTemplate(name string) *template.Template {
 	}
 	tmpl.Funcs(sprig.TxtFuncMap()).Funcs(template.FuncMap{
 		"closest":                 arrayClosest,
-		"coalesce":                coalesce,
 		"comment":                 comment,
 		"contains":                contains,
 		"dir":                     dirList,
@@ -71,19 +70,16 @@ func newTemplate(name string) *template.Template {
 		"groupByMulti":            groupByMulti,
 		"groupByLabel":            groupByLabel,
 		"groupByLabelWithDefault": groupByLabelWithDefault,
-		"json":                    marshalJson,
 		"include":                 include,
 		"intersect":               intersect,
 		"keys":                    keys,
 		"replace":                 strings.Replace,
 		"parseBool":               strconv.ParseBool,
-		"parseJson":               unmarshalJson,
 		"fromYaml":                fromYaml,
 		"toYaml":                  toYaml,
 		"mustFromYaml":            mustFromYaml,
 		"mustToYaml":              mustToYaml,
 		"queryEscape":             url.QueryEscape,
-		"sha1":                    hashSha1,
 		"split":                   strings.Split,
 		"splitN":                  strings.SplitN,
 		"sortStringsAsc":          sortStringsAsc,
@@ -92,8 +88,8 @@ func newTemplate(name string) *template.Template {
 		"sortObjectsByKeysDesc":   sortObjectsByKeysDesc,
 		"trimPrefix":              trimPrefix,
 		"trimSuffix":              trimSuffix,
-		"toLower":                 toLower,
-		"toUpper":                 toUpper,
+		"toLower":                 strings.ToLower,
+		"toUpper":                 strings.ToUpper,
 		"when":                    when,
 		"where":                   where,
 		"whereNot":                whereNot,
@@ -104,6 +100,12 @@ func newTemplate(name string) *template.Template {
 		"whereLabelExists":        whereLabelExists,
 		"whereLabelDoesNotExist":  whereLabelDoesNotExist,
 		"whereLabelValueMatches":  whereLabelValueMatches,
+	}).Funcs(template.FuncMap{
+		// docker-gen template function replaced by their Sprig clone
+		"coalesce":  coalesce,
+		"json":      marshalJson,
+		"parseJson": unmarshalJson,
+		"sha1":      hashSha1,
 	})
 	return tmpl
 }

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -57,7 +57,10 @@ func newTemplate(name string) *template.Template {
 		}
 		return buf.String(), nil
 	}
-	tmpl.Funcs(sprig.TxtFuncMap()).Funcs(template.FuncMap{
+
+	sprigFuncMap := sprig.TxtFuncMap()
+
+	return tmpl.Funcs(sprigFuncMap).Funcs(template.FuncMap{
 		"closest":                 arrayClosest,
 		"comment":                 comment,
 		"contains":                contains,
@@ -86,8 +89,6 @@ func newTemplate(name string) *template.Template {
 		"sortStringsDesc":         sortStringsDesc,
 		"sortObjectsByKeysAsc":    sortObjectsByKeysAsc,
 		"sortObjectsByKeysDesc":   sortObjectsByKeysDesc,
-		"trimPrefix":              trimPrefix,
-		"trimSuffix":              trimSuffix,
 		"toLower":                 strings.ToLower,
 		"toUpper":                 strings.ToUpper,
 		"when":                    when,
@@ -100,14 +101,12 @@ func newTemplate(name string) *template.Template {
 		"whereLabelExists":        whereLabelExists,
 		"whereLabelDoesNotExist":  whereLabelDoesNotExist,
 		"whereLabelValueMatches":  whereLabelValueMatches,
-	}).Funcs(template.FuncMap{
-		// docker-gen template function replaced by their Sprig clone
-		"coalesce":  coalesce,
-		"json":      marshalJson,
-		"parseJson": unmarshalJson,
-		"sha1":      hashSha1,
+
+		// docker-gen template function aliased to their Sprig clone
+		"json":      sprigFuncMap["mustToJson"],
+		"parseJson": sprigFuncMap["mustFromJson"],
+		"sha1":      sprigFuncMap["sha1sum"],
 	})
-	return tmpl
 }
 
 func isBlank(str string) bool {

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -60,8 +60,9 @@ func newTemplate(name string) *template.Template {
 
 	sprigFuncMap := sprig.TxtFuncMap()
 
-	return tmpl.Funcs(sprigFuncMap).Funcs(template.FuncMap{
+	tmpl.Funcs(sprigFuncMap).Funcs(template.FuncMap{
 		"closest":                 arrayClosest,
+		"coalesce":                coalesce,
 		"comment":                 comment,
 		"contains":                contains,
 		"dir":                     dirList,
@@ -108,12 +109,15 @@ func newTemplate(name string) *template.Template {
 		"sha1":      sprigFuncMap["sha1sum"],
 
 		// aliases to sprig template functions masked by docker-gen functions with the same name
+		"sprigCoalesce": sprigFuncMap["coalesce"],
 		"sprigContains": sprigFuncMap["contains"],
 		"sprigDir":      sprigFuncMap["dir"],
 		"sprigReplace":  sprigFuncMap["replace"],
 		"sprigSplit":    sprigFuncMap["split"],
 		"sprigSplitn":   sprigFuncMap["splitn"],
 	})
+
+	return tmpl
 }
 
 func isBlank(str string) bool {

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -106,6 +106,13 @@ func newTemplate(name string) *template.Template {
 		"json":      sprigFuncMap["mustToJson"],
 		"parseJson": sprigFuncMap["mustFromJson"],
 		"sha1":      sprigFuncMap["sha1sum"],
+
+		// aliases to sprig template functions masked by docker-gen functions with the same name
+		"sprigContains": sprigFuncMap["contains"],
+		"sprigDir":      sprigFuncMap["dir"],
+		"sprigReplace":  sprigFuncMap["replace"],
+		"sprigSplit":    sprigFuncMap["split"],
+		"sprigSplitn":   sprigFuncMap["splitn"],
 	})
 }
 

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -102,7 +102,7 @@ func newTemplate(name string) *template.Template {
 		"whereLabelDoesNotExist":  whereLabelDoesNotExist,
 		"whereLabelValueMatches":  whereLabelValueMatches,
 
-		// docker-gen template function aliased to their Sprig clone
+		// legacy docker-gen template function aliased to their Sprig clone
 		"json":      sprigFuncMap["mustToJson"],
 		"parseJson": sprigFuncMap["mustFromJson"],
 		"sha1":      sprigFuncMap["sha1sum"],


### PR DESCRIPTION
This PR cleans up the template functions.

`json` / `parseJson` / `sha1` have been made alias of Sprig functions that behave identically:
| docker-gen |     sprig    |
|:----------:|:------------:|
| `json `      | `mustToJson`   |
| `parseJson ` | `mustFromJson` |
| `sha1`       | `sha1sum`      |

`trimPrefix` / `trimSuffix` have been removed because Sprig already have functions with the same name that do the same thing.

Sprig function that have the same name as existing docker-gen functions and where thus masked have been made available with the `sprig` prefix:
- `sprigCoalesce`
- `sprigContains`
- `sprigDir`
- `sprigReplace`
- `sprigSplit`
- `sprigSplitn`