### PR TITLE
ci: add workflows permissions

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -1,5 +1,8 @@
 name: Release assets
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:

--- a/.github/workflows/build-publish-dispatch.yml
+++ b/.github/workflows/build-publish-dispatch.yml
@@ -1,5 +1,9 @@
 name: Build and publish Docker images on demand
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,5 +1,9 @@
 name: Build and publish Docker images
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,5 +1,8 @@
 name: Update Docker Hub Description
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
This PR add the relevant [`permissions`](https://docs.github.com/fr/actions/reference/workflows-and-actions/workflow-syntax#permissions) to the GitHub Actions workflows.