### PR TITLE
feat: add lexists template function

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ server {{ $net.IP }}:{{ (index $value.Addresses 0).Port }};
 - _`contains $map $key`_: Returns `true` if `$map` contains `$key`. Takes maps from `string` to any type.
 - _`dir $path`_: Returns an array of filenames in the specified `$path`.
 - _`exists $path`_: Returns `true` if `$path` refers to an existing file or directory. Takes a string.
+- _`lexists $path`_: Like `exists`, but does not follow symlinks — returns `true` for a symlink itself even when its target is missing. Takes a string.
 - _`eval $templateName [$data]`_: Evaluates the named template like Go's built-in `template` action, but instead of writing out the result it returns the result as a string so that it can be post-processed. The `$data` argument may be omitted, which is equivalent to passing `nil`.
 - _`groupBy $containers $fieldPath`_: Groups an array of `RuntimeContainer` instances based on the values of a field path expression `$fieldPath`. A field path expression is a dot-delimited list of map keys or struct member names specifying the path from container to a nested value, which must be a string. Returns a map from the value of the field path expression to an array of containers having that value. Containers that do not have a value for the field path in question are omitted.
 - _`groupByWithDefault $containers $fieldPath $defaultValue`_: Returns the same as `groupBy`, but containers that do not have a value for the field path are instead included in the map under the `$defaultValue` key.

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -69,6 +69,7 @@ func newTemplate(name string) *template.Template {
 		"dir":                     dirList,
 		"eval":                    eval,
 		"exists":                  utils.PathExists,
+		"lexists":                 utils.PathLExists,
 		"groupBy":                 groupBy,
 		"groupByWithDefault":      groupByWithDefault,
 		"groupByKeys":             groupByKeys,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -34,3 +34,14 @@ func PathExists(path string) (bool, error) {
 	}
 	return false, err
 }
+
+func PathLExists(path string) (bool, error) {
+	_, err := os.Lstat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -35,6 +35,9 @@ func PathExists(path string) (bool, error) {
 	return false, err
 }
 
+// PathLExists returns whether the given file or directory exists or not,
+// without following symlinks: a symlink whose target is missing still reports
+// as existing.
 func PathLExists(path string) (bool, error) {
 	_, err := os.Lstat(path)
 	if err == nil {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -45,3 +45,36 @@ func TestPathExists(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, exists)
 }
+
+func TestPathLExists(t *testing.T) {
+	file, err := os.CreateTemp("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		file.Close()
+		os.Remove(file.Name())
+	}()
+
+	ok, err := PathLExists(file.Name())
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = PathLExists("/wrong/path")
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	link := file.Name() + "-link"
+	if err := os.Symlink("/wrong/path", link); err != nil {
+		t.Skipf("symlinks unavailable: %s", err)
+	}
+	defer os.Remove(link)
+
+	ok, err = PathLExists(link)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = PathExists(link)
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,28 +48,27 @@ func TestPathExists(t *testing.T) {
 }
 
 func TestPathLExists(t *testing.T) {
-	file, err := os.CreateTemp("", "test")
-	if err != nil {
+	dir := t.TempDir()
+
+	file := filepath.Join(dir, "file")
+	if err := os.WriteFile(file, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		file.Close()
-		os.Remove(file.Name())
-	}()
+	// Never created, so it is guaranteed not to exist on any platform.
+	missing := filepath.Join(dir, "missing")
 
-	ok, err := PathLExists(file.Name())
+	ok, err := PathLExists(file)
 	assert.NoError(t, err)
 	assert.True(t, ok)
 
-	ok, err = PathLExists("/wrong/path")
+	ok, err = PathLExists(missing)
 	assert.NoError(t, err)
 	assert.False(t, ok)
 
-	link := file.Name() + "-link"
-	if err := os.Symlink("/wrong/path", link); err != nil {
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(missing, link); err != nil {
 		t.Skipf("symlinks unavailable: %s", err)
 	}
-	defer os.Remove(link)
 
 	ok, err = PathLExists(link)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary

Adds a `lexists` template function — the `os.Lstat` counterpart of the existing `exists`.

`exists` is backed by `os.Stat`, which **follows** symlinks, so a symlink whose target is missing (a dangling link) reports as non-existent. `lexists` uses `os.Lstat`, which stats the link itself without following it, so it returns `true` for the symlink even when its target is unavailable. This is the behaviour requested in #187 (check for existence without traversing the symlink).

## Change

- `internal/utils`: add `PathLExists`, mirroring `PathExists` but using `os.Lstat` instead of `os.Stat` (same `fs.ErrNotExist` handling).
- `internal/template`: register it in the template `FuncMap` as `lexists`, next to `exists`.
- `README.md`: document `lexists` alongside `exists`.

## Tests

`TestPathLExists` covers an existing file (`true`), a missing path (`false`), and — the distinguishing case — a **dangling symlink**, asserting `lexists` returns `true` while `exists` returns `false`. The symlink portion is skipped where symlink creation isn't permitted (e.g. Windows without the privilege).

Fixes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)