### PR TITLE
fix: handle SIGINT/SIGTERM during initial generation

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -32,6 +32,7 @@ type generator struct {
 	wg                    sync.WaitGroup
 	retry                 bool
 	getCurrentContainerID func(...string) string
+	signalChannel         func() (<-chan os.Signal, func())
 }
 
 type GeneratorConfig struct {
@@ -83,7 +84,29 @@ func NewGenerator(gc GeneratorConfig) (*generator, error) {
 }
 
 func (g *generator) Generate() error {
+	if g.signalChannel == nil {
+		g.signalChannel = newSignalChannel
+	}
+
+	var sigChan <-chan os.Signal
+	if g.hasWatcher() {
+		var cleanup func()
+		sigChan, cleanup = g.signalChannel()
+		defer cleanup()
+	}
+
 	g.generateFromContainers()
+
+	select {
+	case sig := <-sigChan:
+		switch sig {
+		case syscall.SIGTERM, syscall.SIGINT:
+			log.Printf("Received signal: %s\n", sig)
+			return nil
+		}
+	default:
+	}
+
 	g.generateAtInterval()
 	g.generateFromEvents()
 	g.generateFromSignals()
@@ -92,17 +115,18 @@ func (g *generator) Generate() error {
 	return nil
 }
 
-func (g *generator) generateFromSignals() {
-	var hasWatcher bool
+func (g *generator) hasWatcher() bool {
 	for _, config := range g.Configs.Config {
 		if config.Watch {
-			hasWatcher = true
-			break
+			return true
 		}
 	}
+	return false
+}
 
+func (g *generator) generateFromSignals() {
 	// If none of the configs need to watch for events, don't watch for signals either
-	if !hasWatcher {
+	if !g.hasWatcher() {
 		return
 	}
 
@@ -110,7 +134,7 @@ func (g *generator) generateFromSignals() {
 	go func() {
 		defer g.wg.Done()
 
-		sigChan, cleanup := newSignalChannel()
+		sigChan, cleanup := g.signalChannel()
 		defer cleanup()
 		for {
 			sig := <-sigChan
@@ -158,7 +182,7 @@ func (g *generator) generateAtInterval() {
 		go func(cfg config.Config) {
 			defer g.wg.Done()
 
-			sigChan, cleanup := newSignalChannel()
+			sigChan, cleanup := g.signalChannel()
 			defer cleanup()
 			for {
 				select {
@@ -230,7 +254,7 @@ func (g *generator) generateFromEvents() {
 	go func() {
 		// channel will be closed by go-dockerclient
 		eventChan := make(chan *docker.APIEvents, 100)
-		sigChan, cleanup := newSignalChannel()
+		sigChan, cleanup := g.signalChannel()
 		defer cleanup()
 
 		for {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -6,7 +6,11 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -304,4 +308,90 @@ func TestGetContainersSetsCurrentContainer(t *testing.T) {
 	current := emptyCtx.CurrentContainer()
 	assert.NotNil(t, current)
 	assert.Equal(t, currentID, current.ID)
+}
+
+func TestGenerateStopsOnSignalDuringInitialGeneration(t *testing.T) {
+	tests := []struct {
+		name string
+		sig  os.Signal
+	}{
+		{"SIGINT", syscall.SIGINT},
+		{"SIGTERM", syscall.SIGTERM},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := log.Writer()
+			log.SetOutput(io.Discard)
+			t.Cleanup(func() { log.SetOutput(orig) })
+
+			var registered, registeredFirst, watchersStarted atomic.Bool
+
+			server, err := dockertest.NewServer("127.0.0.1:0", nil, nil)
+			if err != nil {
+				t.Fatalf("failed to create test server: %s", err)
+			}
+			t.Cleanup(server.Stop)
+			server.CustomHandler("/info", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(`{"Containers":0,"Images":0,"NFd":11,"NGoroutines":21}`))
+			}))
+			server.CustomHandler("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(`{"Version":"19.03.12","Os":"Linux","GoVersion":"go1.13.14","Arch":"amd64","ApiVersion":"1.40"}`))
+			}))
+			server.CustomHandler("/networks", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("[]"))
+			}))
+			server.CustomHandler("/containers/json", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				registeredFirst.Store(registered.Load())
+				w.Write([]byte("[]"))
+			}))
+			server.CustomHandler("/events", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				watchersStarted.Store(true)
+			}))
+
+			serverURL := fmt.Sprintf("tcp://%s", strings.TrimRight(strings.TrimPrefix(server.URL(), "http://"), "/"))
+			client, err := dockerclient.NewDockerClient(serverURL, false, "", "", "")
+			if err != nil {
+				t.Fatalf("failed to create client: %s", err)
+			}
+			client.SkipServerVersionCheck = true
+
+			apiVersion, err := client.Version()
+			if err != nil {
+				t.Fatalf("failed to retrieve version: %s", err)
+			}
+			context.SetDockerEnv(apiVersion)
+
+			dir := t.TempDir()
+			tmpl := filepath.Join(dir, "test.tmpl")
+			if err := os.WriteFile(tmpl, []byte("{{ len . }}"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			sigChan := make(chan os.Signal, 1)
+			sigChan <- tt.sig
+
+			newSigChan := func() (<-chan os.Signal, func()) {
+				registered.Store(true)
+				return sigChan, func() {}
+			}
+
+			cfg := config.Config{
+				Template: tmpl,
+				Dest:     filepath.Join(dir, "test.conf"),
+				Watch:    true,
+			}
+
+			g := &generator{
+				Client:        client,
+				Endpoint:      serverURL,
+				Configs:       config.ConfigFile{Config: []config.Config{cfg}},
+				signalChannel: newSigChan,
+			}
+
+			assert.NoError(t, g.Generate())
+			assert.True(t, registeredFirst.Load())
+			assert.False(t, watchersStarted.Load())
+		})
+	}
 }


### PR DESCRIPTION
## Problem

`Generate()` runs the initial, synchronous `generateFromContainers()` before any of
the watch loops start:

```go
g.generateFromContainers()   // synchronous; signal.Notify has not run yet
g.generateAtInterval()       // newSignalChannel() first runs inside these goroutines
g.generateFromEvents()
g.generateFromSignals()
g.wg.Wait()
```

`signal.Notify` is what suppresses the Go default disposition, and it was only ever
called from inside those goroutines. A `SIGINT` or `SIGTERM` arriving during the
initial generation therefore killed the process outright. The window is not
negligible — the initial pass makes one Docker API round trip per container.

`cmd/docker-gen/main.go` already guards this exact class of problem, but only for
`SIGHUP`:

```go
// SIGHUP is used to trigger generation but go programs call os.Exit(2) at default.
// Ignore the signal until the handler is registered:
signal.Ignore(syscall.SIGHUP)
```

`SIGINT` and `SIGTERM` were left unprotected, which matches the exit status reported
in #201.

## Change

- Register the signal channel *before* the initial generation, and check it once
  generation completes, so docker-gen finishes the in-flight generation and then
  exits gracefully.
- `signal.Ignore` is deliberately **not** used for `SIGINT`/`SIGTERM`. Ignoring them
  would make `docker stop` during startup hang until its timeout and then `SIGKILL` —
  worse than the current behaviour. They have to be received and handled.
- The channel is only registered when a config actually watches, mirroring the
  existing decision in `generateFromSignals` not to watch signals when there is
  nothing to watch. One-shot runs keep their current abort semantics.
- `hasWatcher()` is extracted from `generateFromSignals` so both call sites share it.

## Implementation notes

The signal channel constructor is now injectable on the generator, following the same
pattern as `GetCurrentContainerID`. This makes the ordering testable without sending
real signals to the test process, which also keeps the test running on Windows rather
than being skipped.

## Tests

`TestGenerateStopsOnSignalDuringInitialGeneration` covers `SIGINT` and `SIGTERM`. The
injected constructor records that it ran, and the `/containers/json` handler asserts
that flag was already set when the initial generation reached it — so the test fails
if registration ever moves back after generation. It also asserts `/events` is never
requested, confirming the watch loops do not start.

## Scope

The other causes discussed in #201 are already resolved: the "is a directory" reports
were a bind-mount user error, and the SIGHUP race was fixed by the `signal.Ignore`
call above plus the graceful handler. This PR closes the remaining gap.

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)