### PR TITLE
feat: nginx quoting template function

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,9 @@ server {{ $net.IP }}:{{ (index $value.Addresses 0).Port }};
 - _`whereLabelDoesNotExist $containers $label`_: Filters a slice of containers based on the non-existence of the label `$label`.
 - _`whereLabelValueMatches $containers $label $pattern`_: Filters a slice of containers based on the existence of the label `$label` with values matching the regular expression `$pattern`.
 
+Nginx-specific functions:
+- _`nginxQuote $string`_: Returns `$string` trimmed then enclosed in quotes if it contains any unescaped character that have special meaning in Nginx configuration files. Otherwise, returns `$string` trimmed. Errors if `$string` contains line breaks or both unescaped single and double quotes.
+
 Sprig functions that have the same name as docker-gen function (but different behaviour) are made available with the `sprig` prefix:
 
 - _`sprigCoalesce ...`_: Alias for Sprig's [`coalesce`](https://masterminds.github.io/sprig/defaults.html).

--- a/internal/template/nginx_quote.go
+++ b/internal/template/nginx_quote.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// nginxQuote quotes a string if it contains unescaped Nginx special characters or unescaped quotes.
+// nginxQuote trim then quotes a string if it contains unescaped Nginx special characters or unescaped quotes.
 // It returns an error if the string contains line breaks or both unescaped single and double quotes.
 func nginxQuote(value string) (string, error) {
 	value = strings.TrimSpace(value)
@@ -52,7 +52,7 @@ func hasUnescapedNginxSpecialChars(value string) bool {
 			if i == 0 {
 				// leading nginx special character found
 				return true
-			} else if value[i-1] != '\\' {
+			} else if !isEscapedAt(value, i) {
 				// unescaped nginx special character found
 				return !isQuoted(value)
 			}
@@ -63,37 +63,41 @@ func hasUnescapedNginxSpecialChars(value string) bool {
 
 // hasUnescapedSingleQuote checks if the given string contains an unescaped single quote character.
 func hasUnescapedSingleQuote(value string) bool {
+	length := len(value)
+
 	for i, char := range value {
 		if char == '\'' {
 			switch i {
 			case 0: // leading single quote
-				if len(value) < 2 {
+				if length < 2 {
 					// value is a single quote character
 					return true
 				}
-				if value[len(value)-1] != '\'' || value[len(value)-2] == '\\' {
+				if value[length-1] != '\'' || isEscapedAt(value, length-1) {
 					// is found without a matching unescaped trailing single quote
 					return true
 				}
-			case len(value) - 1: // trailing single quote
-				if value[i-1] != '\\' && value[0] != '\'' {
+			case length - 1: // trailing single quote
+				if !isEscapedAt(value, i) && value[0] != '\'' {
 					// is not escaped and found without a matching leading single quote
 					return true
 				}
 			default:
-				if value[i-1] != '\\' {
+				if !isEscapedAt(value, i) {
 					// unescaped single quote is found in the middle of the string
 					return !isDoubleQuoted(value)
 				}
 			}
 		}
 	}
+
 	return false
 }
 
 // hasUnescapedDoubleQuote checks if the given string contains an unescaped double quote character.
 func hasUnescapedDoubleQuote(value string) bool {
 	length := len(value)
+
 	for i, char := range value {
 		if char == '"' {
 			switch i {
@@ -102,23 +106,24 @@ func hasUnescapedDoubleQuote(value string) bool {
 					// value is a double quote character
 					return true
 				}
-				if value[length-1] != '"' || value[length-2] == '\\' {
+				if value[length-1] != '"' || isEscapedAt(value, length-1) {
 					// is found without a matching unescaped trailing double quote
 					return true
 				}
 			case length - 1: // trailing double quote
-				if value[i-1] != '\\' && value[0] != '"' {
+				if !isEscapedAt(value, i) && value[0] != '"' {
 					// is not escaped and found without a matching leading double quote
 					return true
 				}
 			default:
-				if value[i-1] != '\\' {
+				if !isEscapedAt(value, i) {
 					// unescaped double quote is found in the middle of the string
 					return !isSingleQuoted(value)
 				}
 			}
 		}
 	}
+
 	return false
 }
 
@@ -129,21 +134,37 @@ func isQuoted(value string) bool {
 
 // isSingleQuoted checks if the given string is enclosed in single quotes and the trailing quote is not escaped.
 func isSingleQuoted(value string) bool {
-	if len(value) < 2 {
-		return false
-	}
-	hasLeadingSingleQuote := strings.HasPrefix(value, "'")
-	hasTrailingUnescapedSingleQuote := strings.HasSuffix(value, "'") && value[len(value)-2] != '\\'
-	return hasLeadingSingleQuote && hasTrailingUnescapedSingleQuote
+	return isQuotedWith(value, '\'')
 }
 
 // isDoubleQuoted checks if the given string is enclosed in double quotes and the trailing quote is not escaped.
 func isDoubleQuoted(value string) bool {
-	if len(value) < 2 {
+	return isQuotedWith(value, '"')
+}
+
+// isQuotedWith checks if the given string is enclosed in the specified quote character and the trailing quote is not escaped.
+func isQuotedWith(value string, quoteChar rune) bool {
+	length := len(value)
+
+	if length < 2 {
 		return false
 	}
 
-	hasLeadingDoubleQuote := strings.HasPrefix(value, "\"")
-	hasTrailingUnescapedDoubleQuote := strings.HasSuffix(value, "\"") && value[len(value)-2] != '\\'
-	return hasLeadingDoubleQuote && hasTrailingUnescapedDoubleQuote
+	hasLeadingQuote := strings.HasPrefix(value, string(quoteChar))
+	hasTrailingUnescapedQuote := strings.HasSuffix(value, string(quoteChar)) && !isEscapedAt(value, length-1)
+	return hasLeadingQuote && hasTrailingUnescapedQuote
+}
+
+// isEscapedAt checks whether the character at index i is escaped by an odd-length run of preceding backslashes.
+func isEscapedAt(value string, i int) bool {
+	if i <= 0 || i > len(value) {
+		return false
+	}
+
+	precedingBackslashes := 0
+	for j := i - 1; j >= 0 && value[j] == '\\'; j-- {
+		precedingBackslashes++
+	}
+
+	return precedingBackslashes%2 == 1
 }

--- a/internal/template/nginx_quote.go
+++ b/internal/template/nginx_quote.go
@@ -33,7 +33,7 @@ func nginxQuote(value string) (string, error) {
 	shouldBeQuoted := hasUnescapedNginxSpecialChars(value) || hasUnescapedSingleQuote || hasUnescapedDoubleQuote
 
 	if shouldBeQuoted {
-		// quote the value with single quotes if it contains unescaped single quotes, otherwise use double quotes
+		// quote the value with single quotes if it contains unescaped double quotes, otherwise use double quotes
 		if hasUnescapedDoubleQuote {
 			return fmt.Sprintf("'%s'", value), nil
 		}

--- a/internal/template/nginx_quote.go
+++ b/internal/template/nginx_quote.go
@@ -1,0 +1,149 @@
+package template
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// nginxQuote quotes a string if it contains unescaped Nginx special characters or unescaped quotes.
+// It returns an error if the string contains line breaks or both unescaped single and double quotes.
+func nginxQuote(value string) (string, error) {
+	value = strings.TrimSpace(value)
+
+	if value == "" {
+		return "", nil
+	}
+
+	// error if the value contains line breaks
+	lineBreaks := []string{"\n", "\r"}
+	for _, char := range lineBreaks {
+		if strings.Contains(value, char) {
+			return "", fmt.Errorf("value must not contain line breaks: %s", value)
+		}
+	}
+
+	// error if the value contains both unescaped single and double quotes
+	hasUnescapedSingleQuote := hasUnescapedSingleQuote(value)
+	hasUnescapedDoubleQuote := hasUnescapedDoubleQuote(value)
+	if hasUnescapedSingleQuote && hasUnescapedDoubleQuote {
+		return "", fmt.Errorf("value has both unescaped single and double quotes: %s", value)
+	}
+
+	shouldBeQuoted := hasUnescapedNginxSpecialChars(value) || hasUnescapedSingleQuote || hasUnescapedDoubleQuote
+
+	if shouldBeQuoted {
+		// quote the value with single quotes if it contains unescaped single quotes, otherwise use double quotes
+		if hasUnescapedDoubleQuote {
+			return fmt.Sprintf("'%s'", value), nil
+		}
+		return fmt.Sprintf("\"%s\"", value), nil
+	}
+
+	return value, nil
+}
+
+// hasUnescapedNginxSpecialChars checks if the given string contains
+// any unescaped Nginx special characters and is not enclosed in quotes.
+func hasUnescapedNginxSpecialChars(value string) bool {
+	nginxSpecialChars := []rune{'{', '}', ';', '#', ' '}
+	for i, char := range value {
+		if slices.Contains(nginxSpecialChars, char) {
+			if i == 0 {
+				// leading nginx special character found
+				return true
+			} else if value[i-1] != '\\' {
+				// unescaped nginx special character found
+				return !isQuoted(value)
+			}
+		}
+	}
+	return false
+}
+
+// hasUnescapedSingleQuote checks if the given string contains an unescaped single quote character.
+func hasUnescapedSingleQuote(value string) bool {
+	for i, char := range value {
+		if char == '\'' {
+			switch i {
+			case 0: // leading single quote
+				if len(value) < 2 {
+					// value is a single quote character
+					return true
+				}
+				if value[len(value)-1] != '\'' || value[len(value)-2] == '\\' {
+					// is found without a matching unescaped trailing single quote
+					return true
+				}
+			case len(value) - 1: // trailing single quote
+				if value[i-1] != '\\' && value[0] != '\'' {
+					// is not escaped and found without a matching leading single quote
+					return true
+				}
+			default:
+				if value[i-1] != '\\' {
+					// unescaped single quote is found in the middle of the string
+					return !isDoubleQuoted(value)
+				}
+			}
+		}
+	}
+	return false
+}
+
+// hasUnescapedDoubleQuote checks if the given string contains an unescaped double quote character.
+func hasUnescapedDoubleQuote(value string) bool {
+	length := len(value)
+	for i, char := range value {
+		if char == '"' {
+			switch i {
+			case 0: // leading double quote
+				if length < 2 {
+					// value is a double quote character
+					return true
+				}
+				if value[length-1] != '"' || value[length-2] == '\\' {
+					// is found without a matching unescaped trailing double quote
+					return true
+				}
+			case length - 1: // trailing double quote
+				if value[i-1] != '\\' && value[0] != '"' {
+					// is not escaped and found without a matching leading double quote
+					return true
+				}
+			default:
+				if value[i-1] != '\\' {
+					// unescaped double quote is found in the middle of the string
+					return !isSingleQuoted(value)
+				}
+			}
+		}
+	}
+	return false
+}
+
+// isQuoted checks if the given string is enclosed in single or double quotes and the trailing quote is not escaped.
+func isQuoted(value string) bool {
+	return isSingleQuoted(value) || isDoubleQuoted(value)
+}
+
+// isSingleQuoted checks if the given string is enclosed in single quotes and the trailing quote is not escaped.
+func isSingleQuoted(value string) bool {
+	if len(value) < 2 {
+		return false
+	}
+	hasLeadingSingleQuote := strings.HasPrefix(value, "'")
+	hasTrailingUnescapedSingleQuote := strings.HasSuffix(value, "'") && value[len(value)-2] != '\\'
+	return hasLeadingSingleQuote && hasTrailingUnescapedSingleQuote
+}
+
+// isDoubleQuoted checks if the given string is enclosed in double quotes and the trailing quote is not escaped.
+func isDoubleQuoted(value string) bool {
+	if len(value) < 2 {
+		return false
+	}
+
+	hasLeadingDoubleQuote := strings.HasPrefix(value, "\"")
+	hasTrailingUnescapedDoubleQuote := strings.HasSuffix(value, "\"") && value[len(value)-2] != '\\'
+	return hasLeadingDoubleQuote && hasTrailingUnescapedDoubleQuote
+}

--- a/internal/template/nginx_quote.go
+++ b/internal/template/nginx_quote.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// nginxQuote trim then quotes a string if it contains unescaped Nginx special characters or unescaped quotes.
+// nginxQuote trims then quotes a string if it contains unescaped Nginx special characters or unescaped quotes.
 // It returns an error if the string contains line breaks or both unescaped single and double quotes.
 func nginxQuote(value string) (string, error) {
 	value = strings.TrimSpace(value)
@@ -19,7 +19,7 @@ func nginxQuote(value string) (string, error) {
 	lineBreaks := []string{"\n", "\r"}
 	for _, char := range lineBreaks {
 		if strings.Contains(value, char) {
-			return "", fmt.Errorf("value must not contain line breaks: %s", value)
+			return "", fmt.Errorf("value must not contain line breaks: %q", value)
 		}
 	}
 
@@ -27,7 +27,7 @@ func nginxQuote(value string) (string, error) {
 	hasUnescapedSingleQuote := hasUnescapedQuotingChar(value, '\'')
 	hasUnescapedDoubleQuote := hasUnescapedQuotingChar(value, '"')
 	if hasUnescapedSingleQuote && hasUnescapedDoubleQuote {
-		return "", fmt.Errorf("value has both unescaped single and double quotes: %s", value)
+		return "", fmt.Errorf("value has both unescaped single and double quotes: %q", value)
 	}
 
 	shouldBeQuoted := hasUnescapedNginxSpecialChars(value) || hasUnescapedSingleQuote || hasUnescapedDoubleQuote
@@ -35,18 +35,27 @@ func nginxQuote(value string) (string, error) {
 	if shouldBeQuoted {
 		// quote the value with single quotes if it contains unescaped double quotes, otherwise use double quotes
 		if hasUnescapedDoubleQuote {
-			return fmt.Sprintf("'%s'", value), nil
+			return quoteWith(value, '\''), nil
 		}
-		return fmt.Sprintf("\"%s\"", value), nil
+		return quoteWith(value, '"'), nil
 	}
 
 	return value, nil
 }
 
+// quoteWith quotes the given string with the specified quote character.
+func quoteWith(value string, quoteChar rune) string {
+	if strings.HasSuffix(value, "\\") && !isEscapedAt(value, len(value)-1) {
+		// if the value ends with an unescaped backslash, escape it to prevent it from escaping the trailing quote
+		value = value + "\\"
+	}
+	return fmt.Sprintf("%c%s%c", quoteChar, value, quoteChar)
+}
+
 // hasUnescapedNginxSpecialChars checks if the given string contains
 // any unescaped Nginx special characters and is not enclosed in quotes.
 func hasUnescapedNginxSpecialChars(value string) bool {
-	nginxSpecialChars := []rune{'{', '}', ';', '#', ' '}
+	nginxSpecialChars := []rune{'{', '}', ';', '#', ' ', '\t'}
 	for i, char := range value {
 		if slices.Contains(nginxSpecialChars, char) {
 			if i == 0 {
@@ -117,7 +126,7 @@ func isQuotedWith(value string, quoteChar rune) bool {
 
 // isEscapedAt checks whether the character at index i is escaped by an odd-length run of preceding backslashes.
 func isEscapedAt(value string, i int) bool {
-	if i <= 0 || i > len(value) {
+	if i <= 0 || i >= len(value) {
 		return false
 	}
 

--- a/internal/template/nginx_quote.go
+++ b/internal/template/nginx_quote.go
@@ -24,8 +24,8 @@ func nginxQuote(value string) (string, error) {
 	}
 
 	// error if the value contains both unescaped single and double quotes
-	hasUnescapedSingleQuote := hasUnescapedSingleQuote(value)
-	hasUnescapedDoubleQuote := hasUnescapedDoubleQuote(value)
+	hasUnescapedSingleQuote := hasUnescapedQuotingChar(value, '\'')
+	hasUnescapedDoubleQuote := hasUnescapedQuotingChar(value, '"')
 	if hasUnescapedSingleQuote && hasUnescapedDoubleQuote {
 		return "", fmt.Errorf("value has both unescaped single and double quotes: %s", value)
 	}
@@ -61,64 +61,34 @@ func hasUnescapedNginxSpecialChars(value string) bool {
 	return false
 }
 
-// hasUnescapedSingleQuote checks if the given string contains an unescaped single quote character.
-func hasUnescapedSingleQuote(value string) bool {
+// hasUnescapedQuotingChar checks if the given string contains any unescaped quoting characters (single or double quotes).
+func hasUnescapedQuotingChar(value string, quoteChar rune) bool {
 	length := len(value)
 
 	for i, char := range value {
-		if char == '\'' {
+		if char == quoteChar {
 			switch i {
-			case 0: // leading single quote
+			case 0: // leading quote
 				if length < 2 {
-					// value is a single quote character
+					// value is a single quoting character
 					return true
 				}
-				if value[length-1] != '\'' || isEscapedAt(value, length-1) {
-					// is found without a matching unescaped trailing single quote
+				if rune(value[length-1]) != quoteChar || isEscapedAt(value, length-1) {
+					// is found without a matching unescaped trailing quote
 					return true
 				}
-			case length - 1: // trailing single quote
-				if !isEscapedAt(value, i) && value[0] != '\'' {
-					// is not escaped and found without a matching leading single quote
+			case length - 1: // trailing quote
+				if !isEscapedAt(value, i) && rune(value[0]) != quoteChar {
+					// is not escaped and found without a matching leading quote
 					return true
 				}
 			default:
 				if !isEscapedAt(value, i) {
-					// unescaped single quote is found in the middle of the string
-					return !isDoubleQuoted(value)
-				}
-			}
-		}
-	}
-
-	return false
-}
-
-// hasUnescapedDoubleQuote checks if the given string contains an unescaped double quote character.
-func hasUnescapedDoubleQuote(value string) bool {
-	length := len(value)
-
-	for i, char := range value {
-		if char == '"' {
-			switch i {
-			case 0: // leading double quote
-				if length < 2 {
-					// value is a double quote character
-					return true
-				}
-				if value[length-1] != '"' || isEscapedAt(value, length-1) {
-					// is found without a matching unescaped trailing double quote
-					return true
-				}
-			case length - 1: // trailing double quote
-				if !isEscapedAt(value, i) && value[0] != '"' {
-					// is not escaped and found without a matching leading double quote
-					return true
-				}
-			default:
-				if !isEscapedAt(value, i) {
-					// unescaped double quote is found in the middle of the string
-					return !isSingleQuoted(value)
+					// unescaped quote is found in the middle of the string
+					if quoteChar == '"' {
+						return !isQuotedWith(value, '\'')
+					}
+					return !isQuotedWith(value, '"')
 				}
 			}
 		}
@@ -129,17 +99,7 @@ func hasUnescapedDoubleQuote(value string) bool {
 
 // isQuoted checks if the given string is enclosed in single or double quotes and the trailing quote is not escaped.
 func isQuoted(value string) bool {
-	return isSingleQuoted(value) || isDoubleQuoted(value)
-}
-
-// isSingleQuoted checks if the given string is enclosed in single quotes and the trailing quote is not escaped.
-func isSingleQuoted(value string) bool {
-	return isQuotedWith(value, '\'')
-}
-
-// isDoubleQuoted checks if the given string is enclosed in double quotes and the trailing quote is not escaped.
-func isDoubleQuoted(value string) bool {
-	return isQuotedWith(value, '"')
+	return isQuotedWith(value, '\'') || isQuotedWith(value, '"')
 }
 
 // isQuotedWith checks if the given string is enclosed in the specified quote character and the trailing quote is not escaped.

--- a/internal/template/nginx_quote_test.go
+++ b/internal/template/nginx_quote_test.go
@@ -191,7 +191,7 @@ func TestHasUnescapedSingleQuote(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := hasUnescapedSingleQuote(tc.input)
+			got := hasUnescapedQuotingChar(tc.input, '\'')
 			assert.Equal(t, tc.wantValue, got, "hasUnescapedSingleQuote(%q) returned %v; want %v", tc.input, got, tc.wantValue)
 		})
 	}
@@ -263,7 +263,7 @@ func TestHasUnescapedDoubleQuote(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := hasUnescapedDoubleQuote(tc.input)
+			got := hasUnescapedQuotingChar(tc.input, '"')
 			assert.Equal(t, tc.wantValue, got, "hasUnescapedDoubleQuote(%q) returned %v; want %v", tc.input, got, tc.wantValue)
 		})
 	}
@@ -310,7 +310,7 @@ func TestIsSingleQuoted(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := isSingleQuoted(tc.input)
+			got := isQuotedWith(tc.input, '\'')
 			assert.Equal(t, tc.wantValue, got, "isSingleQuoted(%q) returned %v; want %v", tc.input, got, tc.wantValue)
 		})
 	}
@@ -357,7 +357,7 @@ func TestIsDoubleQuoted(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := isDoubleQuoted(tc.input)
+			got := isQuotedWith(tc.input, '"')
 			assert.Equal(t, tc.wantValue, got, "isDoubleQuoted(%q) returned %v; want %v", tc.input, got, tc.wantValue)
 		})
 	}

--- a/internal/template/nginx_quote_test.go
+++ b/internal/template/nginx_quote_test.go
@@ -1,0 +1,386 @@
+package template
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testCase struct {
+	name      string
+	input     string
+	wantValue any
+}
+
+func TestNginxQuote(t *testing.T) {
+	testCases := []testCase{}
+
+	for _, char := range []string{"{", "}", ";", "#", " ", "'"} {
+		testCases = append(
+			testCases,
+			testCase{
+				name:      fmt.Sprintf("string with unescaped %q is quoted", char),
+				input:     fmt.Sprintf(`foo%sbar`, char),
+				wantValue: fmt.Sprintf(`"foo%sbar"`, char),
+			},
+			testCase{
+				name:      fmt.Sprintf("quoted string with unescaped %q is untouched", char),
+				input:     fmt.Sprintf(`"foo%sbar"`, char),
+				wantValue: fmt.Sprintf(`"foo%sbar"`, char),
+			},
+			testCase{
+				name:      fmt.Sprintf("string with escaped %q is untouched", char),
+				input:     fmt.Sprintf(`foo\%sbar`, char),
+				wantValue: fmt.Sprintf(`foo\%sbar`, char),
+			},
+		)
+	}
+
+	testCases = append(
+		testCases,
+		testCase{
+			name:      `string with unescaped " is quoted`,
+			input:     `foo"bar`,
+			wantValue: `'foo"bar'`,
+		},
+		testCase{
+			name:      `quoted string with unescaped " is untouched`,
+			input:     `'foo"bar'`,
+			wantValue: `'foo"bar'`,
+		},
+		testCase{
+			name:      `string with escaped " is untouched`,
+			input:     `foo\"bar`,
+			wantValue: `foo\"bar`,
+		},
+	)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := nginxQuote(tc.input)
+			assert.NoError(t, err, "nginxQuote(%q) returned an unexpected error: %v", tc.input, err)
+			assert.Equal(t, tc.wantValue, got, "nginxQuote(%q) returned %q; want %q", tc.input, got, tc.wantValue)
+		})
+	}
+
+	t.Run("empty string returns empty string", func(t *testing.T) {
+		got, err := nginxQuote("")
+		assert.NoError(t, err, "nginxQuote(\"\") returned an unexpected error: %v", err)
+		assert.Empty(t, got, "nginxQuote(\"\") returned %q; want empty string", got)
+	})
+
+	t.Run("string with line breaks returns error", func(t *testing.T) {
+		got, err := nginxQuote("foo\nbar")
+		assert.Error(t, err, "nginxQuote(\"foo\\nbar\") did not return an error for a string with line breaks")
+		assert.Empty(t, got, "nginxQuote(\"foo\\nbar\") returned %q; want empty string", got)
+	})
+
+	t.Run("string with both unescaped single and double quotes returns error", func(t *testing.T) {
+		got, err := nginxQuote(`foo'bar"baz`)
+		assert.Error(t, err, "nginxQuote(`foo'bar\"baz`) did not return an error for a string with both unescaped single and double quotes")
+		assert.Empty(t, got, "nginxQuote(`foo'bar\"baz`) returned %q; want empty string", got)
+	})
+}
+
+func TestHasUnescapedNginxSpecialChars(t *testing.T) {
+	testCases := []testCase{}
+
+	for _, char := range []string{"{", "}", ";", "#", " "} {
+		testCases = append(
+			testCases,
+			testCase{
+				name:      fmt.Sprintf("unescaped %q is detected", char),
+				input:     fmt.Sprintf(`foo%sbar`, char),
+				wantValue: true,
+			},
+			testCase{
+				name:      fmt.Sprintf("unescaped %q at the beginning is detected", char),
+				input:     fmt.Sprintf(`%sfoobar`, char),
+				wantValue: true,
+			},
+			testCase{
+				name:      fmt.Sprintf("escaped %q is not detected", char),
+				input:     fmt.Sprintf(`foo\%sbar`, char),
+				wantValue: false,
+			},
+			testCase{
+				name:      fmt.Sprintf("unescaped %q in quoted string is not detected", char),
+				input:     fmt.Sprintf(`"foo%sbar"`, char),
+				wantValue: false,
+			},
+		)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasUnescapedNginxSpecialChars(tc.input)
+			assert.Equal(t, tc.wantValue, got, "hasUnescapedNginxSpecialChars(%q) returned %v; want %v", tc.input, got, tc.wantValue)
+		})
+	}
+}
+
+func TestHasUnescapedSingleQuote(t *testing.T) {
+	testCases := []testCase{
+		{
+			name:      "single unescaped single quote is detected",
+			input:     `'`,
+			wantValue: true,
+		},
+		{
+			name:      "unescaped single quote in the middle is detected",
+			input:     `foo'bar`,
+			wantValue: true,
+		},
+		{
+			name:      "unescaped single quote at the beginning is detected",
+			input:     `'foobar`,
+			wantValue: true,
+		},
+		{
+			name:      "unescaped single quote at the end is detected",
+			input:     `foobar'`,
+			wantValue: true,
+		},
+		{
+			name:      "unescaped single quote at the beginning with escaped ending is detected",
+			input:     `'foobar\'`,
+			wantValue: true,
+		},
+		{
+			name:      "unescaped single quote in the middle of a single quoted string is detected",
+			input:     `'foo'bar'`,
+			wantValue: true,
+		},
+		{
+			name:      "escaped single quote is not detected",
+			input:     `foo\'bar`,
+			wantValue: false,
+		},
+		{
+			name:      "escaped single quote at the end is not detected",
+			input:     `foobar\'`,
+			wantValue: false,
+		},
+		{
+			name:      "unescaped single quote in the middle of a double quoted string is not detected",
+			input:     `"foo'bar"`,
+			wantValue: false,
+		},
+		{
+			name:      "empty string is not detected",
+			input:     ``,
+			wantValue: false,
+		},
+		{
+			name:      "single quoted empty string is not detected",
+			input:     `''`,
+			wantValue: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasUnescapedSingleQuote(tc.input)
+			assert.Equal(t, tc.wantValue, got, "hasUnescapedSingleQuote(%q) returned %v; want %v", tc.input, got, tc.wantValue)
+		})
+	}
+}
+
+func TestHasUnescapedDoubleQuote(t *testing.T) {
+	testCases := []testCase{
+		{
+			name:      "single unescaped double quote is detected",
+			input:     `"`,
+			wantValue: true,
+		},
+		{
+			name:      "unescaped double quote in the middle is detected",
+			input:     `foo"bar`,
+			wantValue: true,
+		},
+		{
+			name:      "unescaped double quote at the beginning is detected",
+			input:     `"foobar`,
+			wantValue: true,
+		},
+		{
+			name:      "unescaped double quote at the end is detected",
+			input:     `foobar"`,
+			wantValue: true,
+		},
+		{
+			name:      "unescaped double quote at the beginning with escaped ending is detected",
+			input:     `"foobar\"`,
+			wantValue: true,
+		},
+		{
+			name:      "unescaped double quote inside a double quoted string is detected",
+			input:     `"foo"bar"`,
+			wantValue: true,
+		},
+		{
+			name:      "escaped double quote is not detected",
+			input:     `foo\"bar`,
+			wantValue: false,
+		},
+		{
+			name:      "escaped double quote at the beginning is not detected",
+			input:     `\"foobar`,
+			wantValue: false,
+		},
+		{
+			name:      "escaped double quote at the end is not detected",
+			input:     `foobar\"`,
+			wantValue: false,
+		},
+		{
+			name:      "unescaped double quote inside a single quoted string is not detected",
+			input:     `'foo"bar'`,
+			wantValue: false,
+		},
+		{
+			name:      "empty string is not detected",
+			input:     ``,
+			wantValue: false,
+		},
+		{
+			name:      "double quoted empty string is not detected",
+			input:     `""`,
+			wantValue: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasUnescapedDoubleQuote(tc.input)
+			assert.Equal(t, tc.wantValue, got, "hasUnescapedDoubleQuote(%q) returned %v; want %v", tc.input, got, tc.wantValue)
+		})
+	}
+}
+
+func TestIsSingleQuoted(t *testing.T) {
+	testCases := []testCase{
+		{
+			name:      "single quoted string is recognized",
+			input:     `'quoted'`,
+			wantValue: true,
+		},
+		{
+			name:      "empty single quoted string is recognized",
+			input:     `''`,
+			wantValue: true,
+		},
+		{
+			name:      "single character string is not recognized",
+			input:     `'`,
+			wantValue: false,
+		},
+		{
+			name:      "double quoted string is not recognized",
+			input:     `"quoted"`,
+			wantValue: false,
+		},
+		{
+			name:      "unquoted string is not recognized",
+			input:     `unquoted`,
+			wantValue: false,
+		},
+		{
+			name:      "string quoted with an escaped single quote is not recognized",
+			input:     `'unquoted\'`,
+			wantValue: false,
+		},
+		{
+			name:      "incorrectly quoted string is not recognized",
+			input:     `'unquoted"`,
+			wantValue: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isSingleQuoted(tc.input)
+			assert.Equal(t, tc.wantValue, got, "isSingleQuoted(%q) returned %v; want %v", tc.input, got, tc.wantValue)
+		})
+	}
+}
+
+func TestIsDoubleQuoted(t *testing.T) {
+	testCases := []testCase{
+		{
+			name:      "double quoted string is recognized",
+			input:     `"quoted"`,
+			wantValue: true,
+		},
+		{
+			name:      "empty double quoted string is recognized",
+			input:     `""`,
+			wantValue: true,
+		},
+		{
+			name:      "single character string is not recognized",
+			input:     `"`,
+			wantValue: false,
+		},
+		{
+			name:      "single quoted string is not recognized",
+			input:     `'quoted'`,
+			wantValue: false,
+		},
+		{
+			name:      "unquoted string is not recognized",
+			input:     `unquoted`,
+			wantValue: false,
+		},
+		{
+			name:      "string quoted with an escaped double quote is not recognized",
+			input:     `"unquoted\"`,
+			wantValue: false,
+		},
+		{
+			name:      "incorrectly quoted string is not recognized",
+			input:     `"unquoted'`,
+			wantValue: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isDoubleQuoted(tc.input)
+			assert.Equal(t, tc.wantValue, got, "isDoubleQuoted(%q) returned %v; want %v", tc.input, got, tc.wantValue)
+		})
+	}
+}
+
+func TestIsQuoted(t *testing.T) {
+	testCases := []testCase{
+		{
+			name:      "double quoted string is recognized",
+			input:     `"quoted"`,
+			wantValue: true,
+		},
+		{
+			name:      "single quoted string is recognized",
+			input:     `'quoted'`,
+			wantValue: true,
+		},
+		{
+			name:      "unquoted string is not recognized",
+			input:     `unquoted`,
+			wantValue: false,
+		},
+		{
+			name:      "incorrectly quoted string is not recognized",
+			input:     `"unquoted'`,
+			wantValue: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isQuoted(tc.input)
+			assert.Equal(t, tc.wantValue, got, "isQuoted(%q) returned %v; want %v", tc.input, got, tc.wantValue)
+		})
+	}
+}

--- a/internal/template/nginx_quote_test.go
+++ b/internal/template/nginx_quote_test.go
@@ -25,6 +25,11 @@ func TestNginxQuote(t *testing.T) {
 				wantValue: fmt.Sprintf(`"foo%sbar"`, char),
 			},
 			testCase{
+				name:      fmt.Sprintf("string with incorrectly escaped %q is quoted", char),
+				input:     fmt.Sprintf(`foo\\%sbar`, char),
+				wantValue: fmt.Sprintf(`"foo\\%sbar"`, char),
+			},
+			testCase{
 				name:      fmt.Sprintf("quoted string with unescaped %q is untouched", char),
 				input:     fmt.Sprintf(`"foo%sbar"`, char),
 				wantValue: fmt.Sprintf(`"foo%sbar"`, char),
@@ -43,6 +48,11 @@ func TestNginxQuote(t *testing.T) {
 			name:      `string with unescaped " is quoted`,
 			input:     `foo"bar`,
 			wantValue: `'foo"bar'`,
+		},
+		testCase{
+			name:      `string with incorrectly escaped " is quoted`,
+			input:     `foo\\"bar`,
+			wantValue: `'foo\\"bar'`,
 		},
 		testCase{
 			name:      `quoted string with unescaped " is untouched`,
@@ -381,6 +391,77 @@ func TestIsQuoted(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := isQuoted(tc.input)
 			assert.Equal(t, tc.wantValue, got, "isQuoted(%q) returned %v; want %v", tc.input, got, tc.wantValue)
+		})
+	}
+}
+
+func TestIsEscapedAt(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		index     int
+		wantValue bool
+	}{
+		{
+			name:      "index zero is never escaped",
+			input:     `\a`,
+			index:     0,
+			wantValue: false,
+		},
+		{
+			name:      "negative index is never escaped",
+			input:     `\a`,
+			index:     -1,
+			wantValue: false,
+		},
+		{
+			name:      "index beyond length is never escaped",
+			input:     `abc`,
+			index:     4,
+			wantValue: false,
+		},
+		{
+			name:      "character with no preceding backslash is not escaped",
+			input:     `abc`,
+			index:     2,
+			wantValue: false,
+		},
+		{
+			name:      "character preceded by one backslash is escaped",
+			input:     `a\b`,
+			index:     2,
+			wantValue: true,
+		},
+		{
+			name:      "character preceded by two backslashes is not escaped",
+			input:     `a\\b`,
+			index:     3,
+			wantValue: false,
+		},
+		{
+			name:      "character preceded by three backslashes is escaped",
+			input:     `a\\\b`,
+			index:     4,
+			wantValue: true,
+		},
+		{
+			name:      "character at end of string preceded by one backslash is escaped",
+			input:     `foo\"`,
+			index:     4,
+			wantValue: true,
+		},
+		{
+			name:      "character at end of string preceded by two backslashes is not escaped",
+			input:     `foo\\"`,
+			index:     5,
+			wantValue: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isEscapedAt(tc.input, tc.index)
+			assert.Equal(t, tc.wantValue, got, "isEscapedAt(%q, %d) returned %v; want %v", tc.input, tc.index, got, tc.wantValue)
 		})
 	}
 }

--- a/internal/template/nginx_quote_test.go
+++ b/internal/template/nginx_quote_test.go
@@ -16,7 +16,7 @@ type testCase struct {
 func TestNginxQuote(t *testing.T) {
 	testCases := []testCase{}
 
-	for _, char := range []string{"{", "}", ";", "#", " ", "'"} {
+	for _, char := range []string{"{", "}", ";", "#", " ", "\t", "'"} {
 		testCases = append(
 			testCases,
 			testCase{
@@ -91,6 +91,53 @@ func TestNginxQuote(t *testing.T) {
 		assert.Error(t, err, "nginxQuote(`foo'bar\"baz`) did not return an error for a string with both unescaped single and double quotes")
 		assert.Empty(t, got, "nginxQuote(`foo'bar\"baz`) returned %q; want empty string", got)
 	})
+}
+
+func TestQuoteWith(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		quoteChar rune
+		wantValue string
+	}{
+		{
+			name:      "wraps value with double quotes",
+			input:     `value`,
+			quoteChar: '"',
+			wantValue: `"value"`,
+		},
+		{
+			name:      "wraps value with single quotes",
+			input:     `value`,
+			quoteChar: '\'',
+			wantValue: `'value'`,
+		},
+		{
+			name:      "keeps internal escaped quotes unchanged",
+			input:     `foo\"bar`,
+			quoteChar: '"',
+			wantValue: `"foo\"bar"`,
+		},
+		{
+			name:      "trailing escaped backslash stays unchanged",
+			input:     `foo\\`,
+			quoteChar: '"',
+			wantValue: `"foo\\"`,
+		},
+		{
+			name:      "trailing unescaped backslash is escaped",
+			input:     `foo\`,
+			quoteChar: '"',
+			wantValue: `"foo\\"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := quoteWith(tc.input, tc.quoteChar)
+			assert.Equal(t, tc.wantValue, got, "quoteWith(%q, %q) returned %q; want %q", tc.input, tc.quoteChar, got, tc.wantValue)
+		})
+	}
 }
 
 func TestHasUnescapedNginxSpecialChars(t *testing.T) {
@@ -417,7 +464,13 @@ func TestIsEscapedAt(t *testing.T) {
 		{
 			name:      "index beyond length is never escaped",
 			input:     `abc`,
-			index:     4,
+			index:     3,
+			wantValue: false,
+		},
+		{
+			name:      "non existent character is not escaped",
+			input:     `a\`,
+			index:     2,
 			wantValue: false,
 		},
 		{

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -111,6 +111,7 @@ func newTemplate(name string) *template.Template {
 
 		// nginx validation functions
 		"mustParseHSTS": mustParseHSTS,
+		"nginxQuote":    nginxQuote,
 
 		// legacy docker-gen template function aliased to their Sprig clone
 		"json":      sprigFuncMap["mustToJson"],


### PR DESCRIPTION
This PR adds a template function specific to Nginx / nginx-proxy called `nginxQuote` that safely quote strings that contains characters having a special meaning in the context of an nginx config file, and error if the string can't be safely quoted.